### PR TITLE
Improve error messages when using non classvar type annotation

### DIFF
--- a/python/egglog/egraph.py
+++ b/python/egglog/egraph.py
@@ -494,11 +494,11 @@ class _ClassDeclerationsConstructor:
         locals = self.frame.f_locals.copy()
         locals[self.cls_name] = self.current_cls
         for k, v in get_type_hints(_Dummytype, globalns=self.frame.f_globals, localns=locals).items():
-            if v.__origin__ == ClassVar:
+            if getattr(v, "__origin__", None) == ClassVar:
                 (inner_tp,) = v.__args__
                 _register_constant(decls, ClassVariableRef(self.cls_name, k), inner_tp, None)
             else:
-                msg = "The only supported annotations on class attributes are class vars"
+                msg = f"On class {self.cls_name}, for attribute '{k}', expected a ClassVar, but got {v}"
                 raise NotImplementedError(msg)
 
         # Then register each of its methods

--- a/python/tests/test_high_level.py
+++ b/python/tests/test_high_level.py
@@ -644,3 +644,11 @@ def test_multiple_generics():
 
     assert str(egraph.extract(f())) == "Vec[i64].empty()"
     assert str(egraph.extract(g())) == "Vec[String].empty()"
+
+
+def test_wrong_annotation_error():
+    class ZX(Expr):
+        symbol: str
+
+    with pytest.raises(NotImplementedError):
+        ZX.__egg_decls__  # type: ignore[attr-defined]


### PR DESCRIPTION
Previously, if you did something like `x: str` in a classbody there would be an odd error, since it wouldn't be able to resolve the `__egg_decls__`. This fixes it to be more descriptive.

Thanks for raising Adrian on Zulip: https://egraphs.zulipchat.com/#narrow/stream/375765-egg.2Fegglog/topic/First.20time.20user.20of.20python.20bindings/near/421756317