### PR TITLE
Add initial support for functions at the high level

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -77,4 +77,4 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y graphviz
       - run: pip install -e .[docs] pre-commit
-      - run: pre-commit run --hook-stage --all-files manual docs
+      - run: pre-commit run --hook-stage manual --all-files docs

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,8 +45,8 @@ jobs:
           python-version: "3.10"
           cache: "pip"
       - run: pip install -e .[test] mypy pre-commit
-      - run: pre-commit run --hook-stage manual mypy
-      - run: pre-commit run --hook-stage manual stubtest
+      - run: pre-commit run --hook-stage manual --all-files mypy
+      - run: pre-commit run --hook-stage manual --all-files stubtest
   benchmark:
     runs-on: ubuntu-latest
     steps:
@@ -77,4 +77,4 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y graphviz
       - run: pip install -e .[docs] pre-commit
-      - run: pre-commit run --hook-stage manual docs
+      - run: pre-commit run --hook-stage --all-files manual docs

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,12 +4,19 @@ _This project uses semantic versioning_
 
 ## UNRELEASED
 
+## New Feaatures
+
 - Upgrade [egglog](https://github.com/egraphs-good/egglog/compare/0113af1d6476b75d4319591cc3d675f96a71cdc5...fb4a9f114f9bb93154d6eff0dbab079b5cb4ebb6) ([#143](https://github.com/egraphs-good/egglog-python/pull/143))
-  - Adds `UnstableCombinedRulset` to commands
+  - Adds `bindings.UnstableCombinedRulset` to commands
   - Adds `UnstableFn` sort
-- Add ability to use `UnstableFn` in the high level bindings
-  - Also adds ability to refer to methods and property off of classes instead of only off of instances
-  - Fixes a bug where you could not write binary dunder methods (like `__add__`) that didn't have symetric arguments
+- Adds high level function references using `UnstableFn`
+- Adds way to combine ruleset with `r1 | r2` syntax or the experimental `unstable_combine_rulesets(*rs, name=None)` function.
+
+## Minor improvements
+
+- Fixes a bug where you could not write binary dunder methods (like `__add__`) that didn't have symetric arguments
+- Use function name as ruleset name by default when creating ruleset from function
+- Adds ability to refer to methods and property off of classes instead of only off of instances (i.e. `Math.__add__(x, y)`)
 
 ## 7.0.0 (2024-04-27)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,7 +9,7 @@ _This project uses semantic versioning_
 - Upgrade [egglog](https://github.com/egraphs-good/egglog/compare/0113af1d6476b75d4319591cc3d675f96a71cdc5...fb4a9f114f9bb93154d6eff0dbab079b5cb4ebb6) ([#143](https://github.com/egraphs-good/egglog-python/pull/143))
   - Adds `bindings.UnstableCombinedRulset` to commands
   - Adds `UnstableFn` sort
-- Adds high level function references using `UnstableFn`
+- Adds support for first class functions as values using Python's built in `Callable` syntax and `partial`.
 - Adds way to combine ruleset with `r1 | r2` syntax or the experimental `unstable_combine_rulesets(*rs, name=None)` function.
 
 ## Minor improvements

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,9 +4,11 @@ _This project uses semantic versioning_
 
 ## UNRELEASED
 
-- Upgrade [egglog](https://github.com/egraphs-good/egglog/compare/0113af1d6476b75d4319591cc3d675f96a71cdc5...fb4a9f114f9bb93154d6eff0dbab079b5cb4ebb6)
+- Upgrade [egglog](https://github.com/egraphs-good/egglog/compare/0113af1d6476b75d4319591cc3d675f96a71cdc5...fb4a9f114f9bb93154d6eff0dbab079b5cb4ebb6) ([#143](https://github.com/egraphs-good/egglog-python/pull/143))
   - Adds `UnstableCombinedRulset` to commands
   - Adds `UnstableFn` sort
+- Add ability to use `UnstableFn` in the high level bindings
+  - Also adds ability to refer to methods and property off of classes instead of only off of instances
 
 ## 7.0.0 (2024-04-27)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@ _This project uses semantic versioning_
   - Adds `UnstableFn` sort
 - Add ability to use `UnstableFn` in the high level bindings
   - Also adds ability to refer to methods and property off of classes instead of only off of instances
+  - Fixes a bug where you could not write binary dunder methods (like `__add__`) that didn't have symetric arguments
 
 ## 7.0.0 (2024-04-27)
 

--- a/docs/reference/python-integration.md
+++ b/docs/reference/python-integration.md
@@ -389,7 +389,7 @@ returns the type of its first argument.
 
 Note that dunder methods such as `__setitem__` will automatically be marked as mutating their first argument.
 
-## Functions as Value
+## Functions as Values
 
 In Python, functions are first class objects, and can be passed around as values. You can use the builtin `Callable`
 type annotation to specify that a function is expected as an argument. You can then pass egglog functions directly
@@ -397,6 +397,7 @@ and call them with rewrite rules. For example, here is how you could define a `M
 
 ```{code-cell} python
 from collections.abc import Callable
+from typing import ClassVar
 
 class MathList(Expr):
     EMPTY: ClassVar[MathList]

--- a/docs/reference/python-integration.md
+++ b/docs/reference/python-integration.md
@@ -420,7 +420,7 @@ from functools import partial
 x = MathList.EMPTY.append(Math(1))
 added_two = x.map(partial(Math.__add__, Math(2)))
 
-check_eq(added_two, MathList.EMPTY.append(Math(1) + Math(2)), math_list_ruleset.saturate())
+check_eq(added_two, MathList.EMPTY.append(Math(2) + Math(1)), math_list_ruleset.saturate())
 ```
 
 Note that this is all built on the [unstable function support added as a sort to egglog](https://github.com/egraphs-good/egglog/pull/348).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,7 +197,6 @@ check_untyped_defs = true
 strict_equality = true
 warn_unused_configs = true
 allow_redefinition = true
-enable_incomplete_feature = ["Unpack"]
 exclude = ["__snapshots__", "_build", "^conftest.py$"]
 
 [tool.maturin]

--- a/python/egglog/bindings.pyi
+++ b/python/egglog/bindings.pyi
@@ -494,6 +494,12 @@ class Relation:
 class PrintOverallStatistics:
     def __init__(self) -> None: ...
 
+@final
+class UnstableCombinedRuleset:
+    name: str
+    rulesets: list[str]
+    def __init__(self, name: str, rulesets: list[str]) -> None: ...
+
 _Command: TypeAlias = (
     SetOption
     | Datatype
@@ -521,6 +527,7 @@ _Command: TypeAlias = (
     | CheckProof
     | Relation
     | PrintOverallStatistics
+    | UnstableCombinedRuleset
 )
 
 def termdag_term_to_expr(termdag: TermDag, term: _Term) -> _Expr: ...

--- a/python/egglog/builtins.py
+++ b/python/egglog/builtins.py
@@ -5,12 +5,14 @@ Builtin sorts and function to egg.
 
 from __future__ import annotations
 
+from functools import partial
 from typing import TYPE_CHECKING, Generic, Protocol, TypeAlias, TypeVar, Union, overload
 
 from typing_extensions import TypeVarTuple, Unpack
 
 from .conversion import converter
 from .egraph import Expr, Unit, function, method
+from .runtime import RuntimeFunction
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -495,3 +497,7 @@ class UnstableFn(Expr, Generic[T, Unpack[TS]], builtin=True):
 
     @method(egg_fn="unstable-app")
     def __call__(self, *args: Unpack[TS]) -> T: ...
+
+
+converter(RuntimeFunction, UnstableFn, UnstableFn)
+converter(partial, UnstableFn, lambda p: UnstableFn(p.func, *p.args))

--- a/python/egglog/builtins.py
+++ b/python/egglog/builtins.py
@@ -483,8 +483,10 @@ class UnstableFn(Expr, Generic[T, Unpack[TS]], builtin=True):
     @overload
     def __init__(self, f: Callable[[T1, T2, Unpack[TS]], T], _a: T1, _b: T2, /) -> None: ...
 
-    @overload
-    def __init__(self, f: Callable[[T1, T2, T3, Unpack[TS]], T], _a: T1, _b: T2, _c: T3, /) -> None: ...
+    # Removing due to bug in MyPy
+    # https://github.com/python/mypy/issues/17212
+    # @overload
+    # def __init__(self, f: Callable[[T1, T2, T3, Unpack[TS]], T], _a: T1, _b: T2, _c: T3, /) -> None: ...
 
     # etc, for partial application
 

--- a/python/egglog/conversion.py
+++ b/python/egglog/conversion.py
@@ -143,7 +143,7 @@ def resolve_literal(tp: TypeOrVarRef, arg: object) -> RuntimeExpr:
     try:
         tp_just = tp.to_just()
     except NotImplementedError:
-        # If this is a var, it has to be a runtime exprssions
+        # If this is a var, it has to be a runtime expession
         assert isinstance(arg, RuntimeExpr)
         return arg
     if arg_type == tp_just:

--- a/python/egglog/declarations.py
+++ b/python/egglog/declarations.py
@@ -47,6 +47,7 @@ __all__ = [
     "TypedExprDecl",
     "ClassDecl",
     "RulesetDecl",
+    "CombinedRulesetDecl",
     "SaturateDecl",
     "RepeatDecl",
     "SequenceDecl",
@@ -110,7 +111,7 @@ class Declarations:
     _functions: dict[str, FunctionDecl | RelationDecl] = field(default_factory=dict)
     _constants: dict[str, ConstantDecl] = field(default_factory=dict)
     _classes: dict[str, ClassDecl] = field(default_factory=dict)
-    _rulesets: dict[str, RulesetDecl] = field(default_factory=lambda: {"": RulesetDecl([])})
+    _rulesets: dict[str, RulesetDecl | CombinedRulesetDecl] = field(default_factory=lambda: {"": RulesetDecl([])})
 
     @classmethod
     def create(cls, *others: DeclerationsLike) -> Declarations:
@@ -196,7 +197,7 @@ class ClassDecl:
     preserved_methods: dict[str, Callable] = field(default_factory=dict)
 
 
-@dataclass
+@dataclass(frozen=True)
 class RulesetDecl:
     rules: list[RewriteOrRuleDecl]
 
@@ -204,6 +205,11 @@ class RulesetDecl:
     # made into strings
     def __hash__(self) -> int:
         return hash((type(self), tuple(self.rules)))
+
+
+@dataclass(frozen=True)
+class CombinedRulesetDecl:
+    rulesets: tuple[str, ...]
 
 
 # Have two different types of type refs, one that can include vars recursively and one that cannot.

--- a/python/egglog/egraph.py
+++ b/python/egglog/egraph.py
@@ -151,8 +151,8 @@ def check_eq(x: EXPR, y: EXPR, schedule: Schedule | None = None) -> None:
     Verifies that two expressions are equal after running the schedule.
     """
     egraph = EGraph()
-    x = egraph.let("x", x)
-    y = egraph.let("y", y)
+    x = egraph.let("__check_eq_x", x)
+    y = egraph.let("__check_eq_y", y)
     if schedule:
         egraph.run(schedule)
     egraph.check(eq(x).to(y))

--- a/python/egglog/egraph.py
+++ b/python/egglog/egraph.py
@@ -75,6 +75,7 @@ __all__ = [
     "seq",
     "Command",
     "simplify",
+    "unstable_combine_rulesets",
     "check",
     "GraphvizKwargs",
     "Ruleset",
@@ -958,13 +959,12 @@ class EGraph(_BaseModule):
         """
         Displays the e-graph in the notebook.
         """
-        graphviz = self.graphviz(**kwargs)
         if IN_IPYTHON:
             from IPython.display import SVG, display
 
             display(SVG(self.graphviz_svg(**kwargs)))
         else:
-            graphviz.render(view=True, format="svg", quiet=True)
+            self.graphviz(**kwargs).render(view=True, format="svg", quiet=True)
 
     def input(self, fn: Callable[..., String], path: str) -> None:
         """

--- a/python/egglog/egraph.py
+++ b/python/egglog/egraph.py
@@ -677,6 +677,10 @@ def _fn_decl(
         raise NotImplementedError(f"Can only generate function decls for functions not {fn}  {type(fn)}")
 
     hint_globals = fn.__globals__.copy()
+    # Copy Callable into global if not present bc sometimes it gets automatically removed by ruff to type only block
+    # https://docs.astral.sh/ruff/rules/typing-only-standard-library-import/
+    if "Callable" not in hint_globals:
+        hint_globals["Callable"] = Callable
 
     hints = get_type_hints(fn, hint_globals, hint_locals)
 

--- a/python/egglog/egraph.py
+++ b/python/egglog/egraph.py
@@ -1088,7 +1088,7 @@ class EGraph(_BaseModule):
         runtime_expr = to_runtime_expr(expr)
         self._add_decls(runtime_expr)
         typed_expr = runtime_expr.__egg_typed_expr__
-        extract_report = self._run_extract(typed_expr.expr, 0)
+        extract_report = self._run_extract(typed_expr, 0)
 
         if not isinstance(extract_report, bindings.Best):
             msg = "No extract report saved"
@@ -1108,15 +1108,16 @@ class EGraph(_BaseModule):
         self._add_decls(runtime_expr)
         typed_expr = runtime_expr.__egg_typed_expr__
 
-        extract_report = self._run_extract(typed_expr.expr, n)
+        extract_report = self._run_extract(typed_expr, n)
         if not isinstance(extract_report, bindings.Variants):
             msg = "Wrong extract report type"
             raise ValueError(msg)  # noqa: TRY004
         new_exprs = self._state.exprs_from_egg(extract_report.termdag, extract_report.terms, typed_expr.tp)
         return [cast(EXPR, RuntimeExpr.__from_value__(self.__egg_decls__, expr)) for expr in new_exprs]
 
-    def _run_extract(self, expr: ExprDecl, n: int) -> bindings._ExtractReport:
-        expr = self._state.expr_to_egg(expr)
+    def _run_extract(self, typed_expr: TypedExprDecl, n: int) -> bindings._ExtractReport:
+        self._state.type_ref_to_egg(typed_expr.tp)
+        expr = self._state.expr_to_egg(typed_expr.expr)
         self._egraph.run_program(bindings.ActionCommand(bindings.Extract(expr, bindings.Lit(bindings.Int(n)))))
         extract_report = self._egraph.extract_report()
         if not extract_report:

--- a/python/egglog/egraph.py
+++ b/python/egglog/egraph.py
@@ -152,11 +152,15 @@ def check_eq(x: EXPR, y: EXPR, schedule: Schedule | None = None) -> None:
     Verifies that two expressions are equal after running the schedule.
     """
     egraph = EGraph()
-    x = egraph.let("__check_eq_x", x)
-    y = egraph.let("__check_eq_y", y)
+    x_var = egraph.let("__check_eq_x", x)
+    y_var = egraph.let("__check_eq_y", y)
     if schedule:
         egraph.run(schedule)
-    egraph.check(eq(x).to(y))
+    fact = eq(x_var).to(y_var)
+    try:
+        egraph.check(fact)
+    except bindings.EggSmolError as err:
+        raise AssertionError(f"Failed {eq(x).to(y)}\n -> {ne(egraph.extract(x)).to(egraph.extract(y))})") from err
 
 
 def check(x: FactLike, schedule: Schedule | None = None, *given: ActionLike) -> None:

--- a/python/egglog/egraph.py
+++ b/python/egglog/egraph.py
@@ -88,6 +88,7 @@ __all__ = [
     "Fact",
     "Action",
     "Command",
+    "check_eq",
 ]
 
 T = TypeVar("T")
@@ -143,6 +144,18 @@ def simplify(x: EXPR, schedule: Schedule | None = None) -> EXPR:
     if schedule:
         return EGraph().simplify(x, schedule)
     return EGraph().extract(x)
+
+
+def check_eq(x: EXPR, y: EXPR, schedule: Schedule | None = None) -> None:
+    """
+    Verifies that two expressions are equal after running the schedule.
+    """
+    egraph = EGraph()
+    x = egraph.let("x", x)
+    y = egraph.let("y", y)
+    if schedule:
+        egraph.run(schedule)
+    egraph.check(eq(x).to(y))
 
 
 def check(x: FactLike, schedule: Schedule | None = None, *given: ActionLike) -> None:

--- a/python/egglog/egraph.py
+++ b/python/egglog/egraph.py
@@ -147,7 +147,7 @@ def simplify(x: EXPR, schedule: Schedule | None = None) -> EXPR:
     return EGraph().extract(x)
 
 
-def check_eq(x: EXPR, y: EXPR, schedule: Schedule | None = None) -> None:
+def check_eq(x: EXPR, y: EXPR, schedule: Schedule | None = None) -> EGraph:
     """
     Verifies that two expressions are equal after running the schedule.
     """
@@ -161,6 +161,7 @@ def check_eq(x: EXPR, y: EXPR, schedule: Schedule | None = None) -> None:
         egraph.check(fact)
     except bindings.EggSmolError as err:
         raise AssertionError(f"Failed {eq(x).to(y)}\n -> {ne(egraph.extract(x)).to(egraph.extract(y))})") from err
+    return egraph
 
 
 def check(x: FactLike, schedule: Schedule | None = None, *given: ActionLike) -> None:

--- a/python/egglog/egraph.py
+++ b/python/egglog/egraph.py
@@ -1301,8 +1301,10 @@ def ruleset(
     """
     Creates a ruleset with the following rules.
 
-    If no name is provided, one is generated based on the current module
+    If no name is provided, try using the name of the funciton.
     """
+    if isinstance(rule_or_generator, FunctionType):
+        name = name or rule_or_generator.__name__
     r = Ruleset(name)
     if rule_or_generator is not None:
         r.register(rule_or_generator, *rules, _increase_frame=True)

--- a/python/egglog/egraph_state.py
+++ b/python/egglog/egraph_state.py
@@ -220,7 +220,7 @@ class EGraphState:
                     type_args: list[bindings._Expr] = [
                         bindings.Call(
                             self.type_ref_to_egg(ref.args[1]),
-                            [bindings.Var(self.type_ref_to_egg(a)) for a in ref.args[1:]],
+                            [bindings.Var(self.type_ref_to_egg(a)) for a in ref.args[2:]],
                         ),
                         bindings.Var(self.type_ref_to_egg(ref.args[0])),
                     ]

--- a/python/egglog/exp/array_api.py
+++ b/python/egglog/exp/array_api.py
@@ -1346,7 +1346,7 @@ def _unique(xs: TupleValue, a: NDArray, shape: TupleInt, copy: OptionalBool):
 
 @array_api_ruleset.register
 def _size(x: NDArray):
-    yield rewrite(x.size).to(x.shape.fold(Int(0), Int.__mul__))
+    yield rewrite(x.size).to(x.shape.fold(Int(1), Int.__mul__))
 
 
 @overload

--- a/python/egglog/pretty.py
+++ b/python/egglog/pretty.py
@@ -106,7 +106,7 @@ def pretty_callable_ref(
     """
     # Pass in three dummy args, which are the max used for any operation that
     # is not a generic function call
-    args: list[ExprDecl] = [LitDecl(ARG_STR)] * 3
+    args: list[ExprDecl] = [VarDecl(ARG_STR)] * 3
     if first_arg:
         args.insert(0, first_arg)
     res = PrettyContext(decls, defaultdict(lambda: 0))._call_inner(

--- a/python/egglog/pretty.py
+++ b/python/egglog/pretty.py
@@ -66,7 +66,7 @@ UNARY_METHODS = {
     "__invert__": "~",
 }
 
-AllDecls: TypeAlias = RulesetDecl | CommandDecl | ActionDecl | FactDecl | ExprDecl | ScheduleDecl
+AllDecls: TypeAlias = RulesetDecl | CombinedRulesetDecl | CommandDecl | ActionDecl | FactDecl | ExprDecl | ScheduleDecl
 
 
 def pretty_decl(
@@ -176,6 +176,8 @@ class TraverseContext:
                         self(f)
             case PartialCallDecl(c):
                 self(c)
+            case CombinedRulesetDecl(_):
+                pass
             case _:
                 assert_never(decl)
 
@@ -276,6 +278,10 @@ class PrettyContext:
                     return f"ruleset(name={ruleset_name!r})", f"ruleset_{ruleset_name}"
                 args = ", ".join(map(self, rules))
                 return f"ruleset({args})", "ruleset"
+            case CombinedRulesetDecl(rulesets):
+                if ruleset_name:
+                    rulesets = (*rulesets, f"name={ruleset_name!r})")
+                return f"unstable_combine_rulesets({', '.join(rulesets)})", "combined_ruleset"
             case SaturateDecl(schedule):
                 return f"{self(schedule, parens=True)}.saturate()", "schedule"
             case RepeatDecl(schedule, times):

--- a/python/egglog/pretty.py
+++ b/python/egglog/pretty.py
@@ -239,7 +239,7 @@ class PrettyContext:
                 return self._call(decl, parens)
             case PartialCallDecl(CallDecl(ref, typed_args, _)):
                 arg_strs = (_pretty_callable(ref), *(self(a.expr, parens=False, unwrap_lit=True) for a in typed_args))
-                return f"UnstableFn({', '.join(arg_strs)}", "fn"
+                return f"UnstableFn({', '.join(arg_strs)})", "fn"
             case PyObjectDecl(value):
                 return repr(value) if unwrap_lit else f"PyObject({value!r})", "PyObject"
             case ActionCommandDecl(action):

--- a/python/egglog/runtime.py
+++ b/python/egglog/runtime.py
@@ -106,7 +106,7 @@ class RuntimeClass(DelayedDeclerations):
         global _PY_OBJECT_CLASS, _UNSTABLE_FN_CLASS
         if (name := self.__egg_tp__.name) == "PyObject":
             _PY_OBJECT_CLASS = self
-        elif name == "UnstableFn":
+        elif name == "UnstableFn" and not self.__egg_tp__.args:
             _UNSTABLE_FN_CLASS = self
 
     def verify(self) -> None:

--- a/python/egglog/runtime.py
+++ b/python/egglog/runtime.py
@@ -501,8 +501,8 @@ def call_method_min_conversion(slf: object, other: object, name: str) -> Runtime
     # find a minimum type that both can be converted to
     # This is so so that calls like `-0.1 * Int("x")` work by upcasting both to floats.
     min_tp = min_convertable_tp(slf, other, name)
-    slf = resolve_literal(min_tp.to_var(), slf)
-    other = resolve_literal(min_tp.to_var(), other)
+    slf = resolve_literal(TypeRefWithVars(min_tp), slf)
+    other = resolve_literal(TypeRefWithVars(min_tp), other)
     method = RuntimeFunction(Thunk.value(slf.__egg_decls__), MethodRef(slf.__egg_class_name__, name), slf)
     return method(other)
 

--- a/python/egglog/runtime.py
+++ b/python/egglog/runtime.py
@@ -335,7 +335,7 @@ def to_py_signature(sig: FunctionSignature, decls: Declarations, optional_args: 
         )
         for n, d, t in zip(sig.arg_names, sig.arg_defaults, sig.arg_types, strict=True)
     ]
-    if isinstance(sig, FunctionDecl) and sig.var_arg_type is not None:
+    if isinstance(sig, FunctionSignature) and sig.var_arg_type is not None:
         parameters.append(Parameter("__rest", Parameter.VAR_POSITIONAL))
     return Signature(parameters)
 

--- a/python/egglog/runtime.py
+++ b/python/egglog/runtime.py
@@ -70,6 +70,8 @@ T = TypeVar("T")
 def resolve_type_annotation(decls: Declarations, tp: object) -> TypeOrVarRef:
     """
     Resolves a type object into a type reference.
+
+    Any runtime type object decls will be add to those passed in.
     """
     if isinstance(tp, TypeVar):
         return ClassTypeVarRef(tp.__name__)
@@ -295,7 +297,12 @@ class RuntimeFunction(DelayedDeclerations):
             if isinstance(self.__egg_bound__, RuntimeExpr)
             else self.__egg_bound__
         )
-        if bound_tp and bound_tp.args:
+        if (
+            bound_tp
+            and bound_tp.args
+            # Don't  bind class if we have a first class function arg, b/c we don't support that yet
+            and not function_value
+        ):
             tcs.bind_class(bound_tp)
         arg_exprs = tuple(arg.__egg_typed_expr__ for arg in upcasted_args)
         arg_types = [expr.tp for expr in arg_exprs]

--- a/python/egglog/runtime.py
+++ b/python/egglog/runtime.py
@@ -473,10 +473,14 @@ for name in list(BINARY_METHODS) + list(UNARY_METHODS) + ["__getitem__", "__call
             try:
                 return call_method_min_conversion(self, args[0], __name)
             except ConvertError:
-                return NotImplemented
+                # Defer raising not imeplemented in case the dunder method is not symmetrical, then
+                # we use the standard process
+                pass
         if __name in class_decl.methods:
             fn = RuntimeFunction(Thunk.value(self.__egg_decls__), MethodRef(class_name, __name), self)
             return fn(*args, **kwargs)  # type: ignore[arg-type]
+        if __name in PARTIAL_METHODS:
+            return NotImplemented
         raise TypeError(f"{class_name!r} object does not support {__name}")
 
     setattr(RuntimeExpr, name, _special_method)

--- a/python/egglog/runtime.py
+++ b/python/egglog/runtime.py
@@ -11,7 +11,7 @@ so they are not mangled by Python and can be accessed by the user.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from inspect import Parameter, Signature
 from itertools import zip_longest
 from typing import TYPE_CHECKING, NoReturn, TypeVar, Union, cast, get_args, get_origin
@@ -113,25 +113,47 @@ class RuntimeClass(DelayedDeclerations):
         Create an instance of this kind by calling the __init__ classmethod
         """
         # If this is a literal type, initializing it with a literal should return a literal
-        if self.__egg_tp__.name == "PyObject":
+        if (name := self.__egg_tp__.name) == "PyObject":
             assert len(args) == 1
             return RuntimeExpr.__from_value__(
                 self.__egg_decls__, TypedExprDecl(self.__egg_tp__.to_just(), PyObjectDecl(args[0]))
             )
-        if self.__egg_tp__.name in UNARY_LIT_CLASS_NAMES:
+        if name == "UnstableFn":
+            assert not kwargs
+            fn_arg, *partial_args = args
+            del args
+            # Assumes we don't have types set for UnstableFn w/ generics, that they have to be inferred
+
+            # 1. Create a runtime function for the first arg
+            assert isinstance(fn_arg, RuntimeFunction)
+            # 2. Call it with the partial args, and use untyped vars for the rest of the args
+            res = fn_arg(*partial_args, __egg_partial_function=True)
+            assert res is not None, "Mutable partial functions not supported"
+            # 3. Use the inferred return type and inferred rest arg types as the types of the function, and
+            #    the partially applied args as the args.
+            call = (res_typed_expr := res.__egg_typed_expr__).expr
+            return_tp = res_typed_expr.tp
+            assert isinstance(call, CallDecl), "partial function must be a call"
+            n_args = len(partial_args)
+            value = PartialCallDecl(replace(call, args=call.args[:n_args]))
+            remaining_arg_types = [a.tp for a in call.args[n_args:]]
+            type_ref = JustTypeRef("UnstableFn", (return_tp, *remaining_arg_types))
+            return RuntimeExpr.__from_value__(Declarations.create(self, res), TypedExprDecl(type_ref, value))
+
+        if name in UNARY_LIT_CLASS_NAMES:
             assert len(args) == 1
             assert isinstance(args[0], int | float | str | bool)
             return RuntimeExpr.__from_value__(
                 self.__egg_decls__, TypedExprDecl(self.__egg_tp__.to_just(), LitDecl(args[0]))
             )
-        if self.__egg_tp__.name == UNIT_CLASS_NAME:
+        if name == UNIT_CLASS_NAME:
             assert len(args) == 0
             return RuntimeExpr.__from_value__(
                 self.__egg_decls__, TypedExprDecl(self.__egg_tp__.to_just(), LitDecl(None))
             )
 
         return RuntimeFunction(
-            Thunk.value(self.__egg_decls__), ClassMethodRef(self.__egg_tp__.name, "__init__"), self.__egg_tp__.to_just()
+            Thunk.value(self.__egg_decls__), ClassMethodRef(name, "__init__"), self.__egg_tp__.to_just()
         )(*args, **kwargs)
 
     def __dir__(self) -> list[str]:
@@ -184,6 +206,12 @@ class RuntimeClass(DelayedDeclerations):
             return RuntimeFunction(
                 Thunk.value(self.__egg_decls__), ClassMethodRef(self.__egg_tp__.name, name), self.__egg_tp__.to_just()
             )
+        # allow referencing properties and methods as class variables as well
+        if name in cls_decl.properties:
+            return RuntimeFunction(Thunk.value(self.__egg_decls__), PropertyRef(self.__egg_tp__.name, name))
+        if name in cls_decl.methods:
+            return RuntimeFunction(Thunk.value(self.__egg_decls__), MethodRef(self.__egg_tp__.name, name))
+
         msg = f"Class {self.__egg_tp__.name} has no method {name}"
         if name == "__ne__":
             msg += ". Did you mean to use the ne(...).to(...)?"
@@ -207,21 +235,24 @@ class RuntimeFunction(DelayedDeclerations):
     # bound methods need to store RuntimeExpr not just TypedExprDecl, so they can mutate the expr if required on self
     __egg_bound__: JustTypeRef | RuntimeExpr | None = None
 
-    def __call__(self, *args: object, **kwargs: object) -> RuntimeExpr | None:
+    def __call__(self, *args: object, __egg_partial_function: bool = False, **kwargs: object) -> RuntimeExpr | None:
         from .conversion import resolve_literal
 
         if isinstance(self.__egg_bound__, RuntimeExpr):
             args = (self.__egg_bound__, *args)
-        fn_decl = self.__egg_decls__.get_callable_decl(self.__egg_ref__).to_function_decl()
+        signature = self.__egg_decls__.get_callable_decl(self.__egg_ref__).to_function_decl().signature
+        assert isinstance(signature, FunctionSignature)
+
         # Turn all keyword args into positional args
-        bound = callable_decl_to_signature(fn_decl, self.__egg_decls__).bind(*args, **kwargs)
+        bound = to_py_signature(signature, self.__egg_decls__, __egg_partial_function).bind(*args, **kwargs)
+        del kwargs
         bound.apply_defaults()
         assert not bound.kwargs
-        del args, kwargs
+        args = bound.args
 
         upcasted_args = [
             resolve_literal(cast(TypeOrVarRef, tp), arg)
-            for arg, tp in zip_longest(bound.args, fn_decl.arg_types, fillvalue=fn_decl.var_arg_type)
+            for arg, tp in zip_longest(args, signature.arg_types, fillvalue=signature.var_arg_type)
         ]
 
         decls = Declarations.create(self, *upcasted_args)
@@ -240,13 +271,13 @@ class RuntimeFunction(DelayedDeclerations):
         arg_types = [expr.tp for expr in arg_exprs]
         cls_name = bound_tp.name if bound_tp else None
         return_tp = tcs.infer_return_type(
-            fn_decl.arg_types, fn_decl.return_type or fn_decl.arg_types[0], fn_decl.var_arg_type, arg_types, cls_name
+            signature.arg_types, signature.semantic_return_type, signature.var_arg_type, arg_types, cls_name
         )
         bound_params = cast(JustTypeRef, bound_tp).args if isinstance(self.__egg_ref__, ClassMethodRef) else None
         expr_decl = CallDecl(self.__egg_ref__, arg_exprs, bound_params)
         typed_expr_decl = TypedExprDecl(return_tp, expr_decl)
         # If there is not return type, we are mutating the first arg
-        if not fn_decl.return_type:
+        if not signature.return_type:
             first_arg = upcasted_args[0]
             first_arg.__egg_thunk__ = Thunk.value((decls, typed_expr_decl))
             return None
@@ -262,19 +293,26 @@ class RuntimeFunction(DelayedDeclerations):
         return pretty_callable_ref(self.__egg_decls__, self.__egg_ref__, first_arg, bound_tp_params)
 
 
-def callable_decl_to_signature(
-    decl: FunctionDecl,
-    decls: Declarations,
-) -> Signature:
+def to_py_signature(sig: FunctionSignature, decls: Declarations, optional_args: bool) -> Signature:
+    """
+    Convert to a Python signature.
+
+    If optional_args is true, then all args will be treated as optional, as if a default was provided that makes them
+    a var with that arg name as the value.
+
+    Used for partial application to try binding a function with only some of its args.
+    """
     parameters = [
         Parameter(
             n,
             Parameter.POSITIONAL_OR_KEYWORD,
-            default=RuntimeExpr.__from_value__(decls, TypedExprDecl(t.to_just(), d)) if d else Parameter.empty,
+            default=RuntimeExpr.__from_value__(decls, TypedExprDecl(t.to_just(), d if d is not None else VarDecl(n)))
+            if d is not None or optional_args
+            else Parameter.empty,
         )
-        for n, d, t in zip(decl.arg_names, decl.arg_defaults, decl.arg_types, strict=True)
+        for n, d, t in zip(sig.arg_names, sig.arg_defaults, sig.arg_types, strict=True)
     ]
-    if isinstance(decl, FunctionDecl) and decl.var_arg_type is not None:
+    if isinstance(sig, FunctionDecl) and sig.var_arg_type is not None:
         parameters.append(Parameter("__rest", Parameter.VAR_POSITIONAL))
     return Signature(parameters)
 

--- a/python/egglog/thunk.py
+++ b/python/egglog/thunk.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Generic, TypeVar
 
-from typing_extensions import ParamSpec, TypeVarTuple, Unpack
+from typing_extensions import TypeVarTuple, Unpack
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -12,7 +12,6 @@ if TYPE_CHECKING:
 __all__ = ["Thunk"]
 
 T = TypeVar("T")
-P = ParamSpec("P")
 TS = TypeVarTuple("TS")
 
 

--- a/python/tests/test_high_level.py
+++ b/python/tests/test_high_level.py
@@ -631,7 +631,7 @@ def test_deferred_ruleset():
     )
 
 
-def test_access_method_on_class(self):
+def test_access_method_on_class():
     class A(Expr):
         def __init__(self) -> None: ...
 
@@ -640,7 +640,7 @@ def test_access_method_on_class(self):
     assert expr_parts(A.b(A(), 1)) == expr_parts(A().b(1))
 
 
-def test_access_property_on_class(self):
+def test_access_property_on_class():
     class A(Expr):
         def __init__(self) -> None: ...
 

--- a/python/tests/test_high_level.py
+++ b/python/tests/test_high_level.py
@@ -629,3 +629,22 @@ def test_deferred_ruleset():
         rules,
         first(AA()),
     )
+
+
+def test_access_method_on_class(self):
+    class A(Expr):
+        def __init__(self) -> None: ...
+
+        def b(self, x: i64Like) -> A: ...
+
+    assert expr_parts(A.b(A(), 1)) == expr_parts(A().b(1))
+
+
+def test_access_property_on_class(self):
+    class A(Expr):
+        def __init__(self) -> None: ...
+
+        @property
+        def b(self) -> i64: ...
+
+    assert expr_parts(A.b(A())) == expr_parts(A().b)

--- a/python/tests/test_runtime.py
+++ b/python/tests/test_runtime.py
@@ -27,7 +27,7 @@ def test_function_call():
             "i64": ClassDecl(),
         },
         _functions={
-            "one": FunctionDecl((), (), (), TypeRefWithVars("i64")),
+            "one": FunctionDecl(FunctionSignature(return_type=TypeRefWithVars("i64"))),
         },
     )
     one = RuntimeFunction(Thunk.value(decls), FunctionRef("one"))
@@ -45,7 +45,7 @@ def test_classmethod_call():
             "unit": ClassDecl(),
             "Map": ClassDecl(
                 type_vars=("K", "V"),
-                class_methods={"create": FunctionDecl((), (), (), TypeRefWithVars("Map", (K, V)))},
+                class_methods={"create": FunctionDecl(FunctionSignature(return_type=TypeRefWithVars("Map", (K, V))))},
             ),
         },
     )
@@ -69,17 +69,18 @@ def test_expr_special():
             "i64": ClassDecl(
                 methods={
                     "__add__": FunctionDecl(
-                        (TypeRefWithVars("i64"), TypeRefWithVars("i64")),
-                        (
-                            "a",
-                            "b",
-                        ),
-                        (None, None),
-                        TypeRefWithVars("i64"),
+                        FunctionSignature(
+                            (TypeRefWithVars("i64"), TypeRefWithVars("i64")),
+                            ("a", "b"),
+                            (None, None),
+                            TypeRefWithVars("i64"),
+                        )
                     )
                 },
                 class_methods={
-                    "__init__": FunctionDecl((TypeRefWithVars("i64"),), ("self",), (None,), TypeRefWithVars("i64"))
+                    "__init__": FunctionDecl(
+                        FunctionSignature((TypeRefWithVars("i64"),), ("self",), (None,), TypeRefWithVars("i64"))
+                    )
                 },
             ),
         },

--- a/python/tests/test_unstable_fn.py
+++ b/python/tests/test_unstable_fn.py
@@ -60,7 +60,7 @@ def square_ruleset(x: Math):
 
 
 def test_call_fn():
-    check(eq(UnstableFn(square)(3)).to(square(3)), None, square(3))
+    check_eq(UnstableFn(square)(3), square(3))
 
 
 def test_string_fn():
@@ -81,11 +81,10 @@ x = MathList(1, MathList(2, MathList(3, None)))
 
 
 def test_map():
-    squared_r = x.map(UnstableFn(square))
-    check(
-        eq(squared_r).to(MathList(1, MathList(4, MathList(9, None)))),
+    check_eq(
+        x.map(UnstableFn(square)),
+        MathList(1, MathList(4, MathList(9, None))),
         (math_ruleset + square_ruleset + map_ruleset).saturate(),
-        squared_r,
     )
 
 
@@ -95,11 +94,10 @@ def list_multiple_ruleset(x: Math, xs: MathList):
 
 
 def test_partial_application():
-    doubled_x = x * 2
-    check(
-        eq(doubled_x).to(MathList(2, MathList(4, MathList(6, None)))),
+    check_eq(
+        x * 2,
+        MathList(2, MathList(4, MathList(6, None))),
         (math_ruleset + list_multiple_ruleset + map_ruleset).saturate(),
-        doubled_x,
     )
 
 
@@ -114,11 +112,10 @@ def composed_math_ruleset(f: MathFn, g: MathFn, x: Math):
 
 def test_composed():
     square_of_double = UnstableFn(composed_math, UnstableFn(square), UnstableFn(Math.__mul__, 2))
-    squared_doubled_x = x.map(square_of_double)
-    check(
-        eq(squared_doubled_x).to(MathList(4, MathList(16, MathList(36, None)))),
+    check_eq(
+        x.map(square_of_double),
+        MathList(4, MathList(16, MathList(36, None))),
         (math_ruleset + square_ruleset + map_ruleset + composed_math_ruleset).saturate(),
-        squared_doubled_x,
     )
 
 
@@ -134,11 +131,10 @@ def composed_i64_math_ruleset(f: MathFn, g: i64Fun, i: i64):
 
 
 def test_composed_i64_math():
-    res = composed_i64_math(UnstableFn(square), UnstableFn(i64.__mul__, 2), 4)
-    check(
-        eq(res).to(square(64)),
+    check_eq(
+        composed_i64_math(UnstableFn(square), UnstableFn(i64.__mul__, 2), 4),
+        square(64),
         (math_ruleset + square_ruleset + composed_i64_math_ruleset).saturate(),
-        res,
     )
 
 

--- a/python/tests/test_unstable_fn.py
+++ b/python/tests/test_unstable_fn.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from functools import partial
 from typing import ClassVar, TypeAlias
 
 from egglog import *
@@ -143,3 +144,11 @@ def test_extract():
     f = UnstableFn(i64.__mul__, i64(2))
     res = EGraph().extract(f)
     assert expr_parts(res) == expr_parts(f)
+
+
+def test_pass_in_function():
+    assert expr_parts(x.map(square)) == expr_parts(x.map(UnstableFn(square)))
+
+
+def test_pass_in_partial():
+    assert expr_parts(x.map(partial(Math.__mul__, Math(2)))) == expr_parts(x.map(UnstableFn(Math.__mul__, Math(2))))

--- a/python/tests/test_unstable_fn.py
+++ b/python/tests/test_unstable_fn.py
@@ -32,7 +32,7 @@ def math_ruleset(x: i64, y: i64):
     yield rewrite(Math(x) * Math(y)).to(Math(x * y))
 
 
-MathFn = UnstableFn[Math, Math]
+MathFn: TypeAlias = UnstableFn[Math, Math]
 
 
 class MathList(Expr):
@@ -68,7 +68,7 @@ def test_string_fn():
 
 
 def test_string_fn_partial():
-    assert str(UnstableFn(Math.__mul__, 2)) == "UnstableFn(Math.__mul__, Math(2))"
+    assert str(UnstableFn(Math.__mul__, Math(2))) == "UnstableFn(Math.__mul__, Math(2))"
 
 
 @ruleset
@@ -111,7 +111,7 @@ def composed_math_ruleset(f: MathFn, g: MathFn, x: Math):
 
 
 def test_composed():
-    square_of_double = UnstableFn(composed_math, UnstableFn(square), UnstableFn(Math.__mul__, 2))
+    square_of_double = UnstableFn(composed_math, UnstableFn(square), UnstableFn(Math.__mul__, Math(2)))  # type: ignore[arg-type]
     check_eq(
         x.map(square_of_double),
         MathList(4, MathList(16, MathList(36, None))),
@@ -128,18 +128,18 @@ def composed_i64_math(f: MathFn, g: i64Fun, i: i64Like) -> Math: ...
 
 @ruleset
 def composed_i64_math_ruleset(f: MathFn, g: i64Fun, i: i64):
-    yield rewrite(composed_i64_math(f, g, i)).to(f(g(i)))
+    yield rewrite(composed_i64_math(f, g, i)).to(f(Math(g(i))))
 
 
 def test_composed_i64_math():
     check_eq(
-        composed_i64_math(UnstableFn(square), UnstableFn(i64.__mul__, 2), 4),
+        composed_i64_math(UnstableFn(square), UnstableFn(i64.__mul__, i64(2)), 4),
         Math(64),
         (math_ruleset | square_ruleset | composed_i64_math_ruleset).saturate(),
     )
 
 
 def test_extract():
-    f = UnstableFn(i64.__mul__, 2)
+    f = UnstableFn(i64.__mul__, i64(2))
     res = EGraph().extract(f)
     assert expr_parts(res) == expr_parts(f)

--- a/python/tests/test_unstable_fn.py
+++ b/python/tests/test_unstable_fn.py
@@ -122,6 +122,7 @@ def test_composed():
 i64Fun: TypeAlias = UnstableFn[i64, i64]  # noqa: N816, PYI042
 
 
+@function
 def composed_i64_math(f: MathFn, g: i64Fun, i: i64Like) -> Math: ...
 
 

--- a/python/tests/test_unstable_fn.py
+++ b/python/tests/test_unstable_fn.py
@@ -1,0 +1,134 @@
+# mypy: disable-error-code="empty-body"
+
+# tests translated from unstable-fn.egg
+
+
+from __future__ import annotations
+
+from typing import ClassVar, TypeAlias
+
+from egglog import *
+
+
+class Math(Expr):
+    def __init__(self, n: i64Like) -> None: ...
+
+    @classmethod
+    def var(cls, s: StringLike) -> Math: ...
+
+    def __add__(self, other: MathLike) -> Math: ...
+
+    def __mul__(self, other: MathLike) -> Math: ...
+
+
+MathLike: TypeAlias = Math | i64Like | StringLike
+
+converter(String, Math, Math.var)
+converter(i64, Math, Math)
+
+
+@ruleset
+def math_ruleset(x: i64, y: i64):
+    yield rewrite(Math(x) * Math(y)).to(Math(x * y))
+
+
+MathFn = UnstableFn[Math, Math]
+
+
+class MathList(Expr):
+    NIL: ClassVar[MathList]
+
+    def __init__(self, m: MathLike, l: MathListLike) -> None: ...
+
+    def map(self, f: MathFn) -> MathList: ...
+
+    def __mul__(self, x: MathLike) -> MathList: ...
+
+
+MathListLike: TypeAlias = MathList | None
+
+converter(type(None), MathList, lambda _: MathList.NIL)
+
+
+@function
+def square(x: MathLike) -> Math: ...
+
+
+@ruleset
+def square_ruleset(x: Math):
+    yield rewrite(square(x)).to(x * x)
+
+
+def test_call_fn():
+    check(eq(UnstableFn(square)(3)).to(square(3)))
+
+
+@ruleset
+def map_ruleset(f: MathFn, x: Math, xs: MathList):
+    yield rewrite(MathList.NIL.map(f)).to(MathList.NIL)
+    yield rewrite(MathList(x, xs).map(f)).to(MathList(f(x), xs.map(f)))
+
+
+x = MathList(1, MathList(2, MathList(3, None)))
+
+
+def test_map():
+    squared_r = x.map(UnstableFn(square))
+    check(
+        eq(squared_r).to(MathList(1, MathList(4, MathList(9, None)))),
+        (math_ruleset + square_ruleset + map_ruleset).saturate(),
+        squared_r,
+    )
+
+
+@ruleset
+def list_multiple_ruleset(x: Math, xs: MathList):
+    yield rewrite(xs * x).to(xs.map(UnstableFn(Math.__mul__, x)))
+
+
+def test_partial_application():
+    doubled_x = x * 2
+    check(
+        eq(doubled_x).to(MathList(2, MathList(4, MathList(6, None)))),
+        (math_ruleset + list_multiple_ruleset + map_ruleset).saturate(),
+        doubled_x,
+    )
+
+
+@function
+def composed_math(f: MathFn, g: MathFn, x: Math) -> Math: ...
+
+
+@ruleset
+def composed_math_ruleset(f: MathFn, g: MathFn, x: Math):
+    yield rewrite(composed_math(f, g, x)).to(f(g(x)))
+
+
+def test_composed():
+    square_of_double = UnstableFn(composed_math, UnstableFn(square), UnstableFn(Math.__mul__, 2))
+    squared_doubled_x = x.map(square_of_double)
+    check(
+        eq(squared_doubled_x).to(MathList(4, MathList(16, MathList(36, None)))),
+        (math_ruleset + square_ruleset + map_ruleset + composed_math_ruleset).saturate(),
+        squared_doubled_x,
+    )
+
+
+i64Fun: TypeAlias = UnstableFn[i64, i64]  # noqa: N816, PYI042
+
+
+def composed_i64_math(f: MathFn, g: i64Fun, i: i64Like) -> Math: ...
+
+
+@ruleset
+def composed_i64_math_ruleset(f: MathFn, g: i64Fun, i: i64):
+    yield rewrite(composed_i64_math(f, g, i)).to(f(g(i)))
+
+
+def test_composed_i64_math():
+    res = composed_i64_math(UnstableFn(square), UnstableFn(i64.__mul__, 2), 4)
+    check(
+        eq(res).to(square(64)),
+        (math_ruleset + square_ruleset + composed_i64_math_ruleset).saturate(),
+        res,
+    )

--- a/python/tests/test_unstable_fn.py
+++ b/python/tests/test_unstable_fn.py
@@ -84,7 +84,7 @@ def test_map():
     check_eq(
         x.map(UnstableFn(square)),
         MathList(1, MathList(4, MathList(9, None))),
-        (math_ruleset + square_ruleset + map_ruleset).saturate(),
+        (math_ruleset | square_ruleset | map_ruleset).saturate(),
     )
 
 
@@ -97,7 +97,7 @@ def test_partial_application():
     check_eq(
         x * 2,
         MathList(2, MathList(4, MathList(6, None))),
-        (math_ruleset + list_multiple_ruleset + map_ruleset).saturate(),
+        (math_ruleset | list_multiple_ruleset | map_ruleset).saturate(),
     )
 
 
@@ -115,7 +115,7 @@ def test_composed():
     check_eq(
         x.map(square_of_double),
         MathList(4, MathList(16, MathList(36, None))),
-        (math_ruleset + square_ruleset + map_ruleset + composed_math_ruleset).saturate(),
+        (math_ruleset | square_ruleset | map_ruleset | composed_math_ruleset).saturate(),
     )
 
 
@@ -134,7 +134,7 @@ def test_composed_i64_math():
     check_eq(
         composed_i64_math(UnstableFn(square), UnstableFn(i64.__mul__, 2), 4),
         square(64),
-        (math_ruleset + square_ruleset + composed_i64_math_ruleset).saturate(),
+        (math_ruleset | square_ruleset | composed_i64_math_ruleset).saturate(),
     )
 
 

--- a/python/tests/test_unstable_fn.py
+++ b/python/tests/test_unstable_fn.py
@@ -134,7 +134,7 @@ def composed_i64_math_ruleset(f: MathFn, g: i64Fun, i: i64):
 def test_composed_i64_math():
     check_eq(
         composed_i64_math(UnstableFn(square), UnstableFn(i64.__mul__, 2), 4),
-        square(64),
+        Math(64),
         (math_ruleset | square_ruleset | composed_i64_math_ruleset).saturate(),
     )
 

--- a/python/tests/test_unstable_fn.py
+++ b/python/tests/test_unstable_fn.py
@@ -63,6 +63,14 @@ def test_call_fn():
     check(eq(UnstableFn(square)(3)).to(square(3)))
 
 
+def test_string_fn():
+    assert str(UnstableFn(square)) == "UnstableFn(square)"
+
+
+def test_string_fn_partial():
+    assert str(UnstableFn(Math.__mul__, 2)) == "UnstableFn(Math.__mul__, 2)"
+
+
 @ruleset
 def map_ruleset(f: MathFn, x: Math, xs: MathList):
     yield rewrite(MathList.NIL.map(f)).to(MathList.NIL)
@@ -132,3 +140,9 @@ def test_composed_i64_math():
         (math_ruleset + square_ruleset + composed_i64_math_ruleset).saturate(),
         res,
     )
+
+
+def test_extract():
+    f = UnstableFn(i64.__mul__, 2)
+    res = EGraph().extract(f)
+    assert expr_parts(res) == expr_parts(f)

--- a/python/tests/test_unstable_fn.py
+++ b/python/tests/test_unstable_fn.py
@@ -60,7 +60,7 @@ def square_ruleset(x: Math):
 
 
 def test_call_fn():
-    check(eq(UnstableFn(square)(3)).to(square(3)))
+    check(eq(UnstableFn(square)(3)).to(square(3)), None, square(3))
 
 
 def test_string_fn():
@@ -68,7 +68,7 @@ def test_string_fn():
 
 
 def test_string_fn_partial():
-    assert str(UnstableFn(Math.__mul__, 2)) == "UnstableFn(Math.__mul__, 2)"
+    assert str(UnstableFn(Math.__mul__, 2)) == "UnstableFn(Math.__mul__, Math(2))"
 
 
 @ruleset

--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -70,7 +70,9 @@ impl EGraph {
     #[pyo3(signature=(*commands))]
     fn run_program(&mut self, commands: Vec<Command>) -> EggResult<Vec<String>> {
         let commands: Vec<egglog::ast::Command> = commands.into_iter().map(|x| x.into()).collect();
-        info!("Running commands {:?}", commands);
+        for cmd in &commands {
+            info!("{}", cmd);
+        }
         if let Some(cmds) = &mut self.cmds {
             for cmd in &commands {
                 cmds.push_str(&cmd.to_string());


### PR DESCRIPTION
This PR adds support for passing functions at the high level API.

All functions need to be wrapped in the `UnstableFn` wrapper, like you need to do in egglog currently. In a follow up PR I will remove this restriction. That way the public API will allow you to use `Callable` as an argument and it will work properly.

TODOs after this:

- [x] Support `Callable` as a type signature for functions arguments
- [x] Support passing functions directly as well as `partial` objects
- [ ] Support passing unnamed functions (lambdas) and automatically generate new high level functions for them and partially apply them.