### PR TITLE
Add support for transforming normal Python functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "egglog-python"
-version = "7.1.0"
+version = "7.2.0"
 dependencies = [
  "egglog",
  "egraph-serialize",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,9 @@ _This project uses semantic versioning_
 
 ## UNRELEASED
 
+- Adds ability to use anonymous functions where callables are needed. These are automatically transformed to egglog
+  functions with default rewrites.
+
 ## 7.2.0 (2024-05-23)
 
 - Adds ability to use function bodies as default rewrites ([#167](https://github.com/egraphs-good/egglog-python/pull/167))

--- a/docs/reference/python-integration.md
+++ b/docs/reference/python-integration.md
@@ -428,6 +428,27 @@ Note that this is all built on the [unstable function support added as a sort to
 While this sort is exposed directly at the high level with the `UnstableFn` class, we don't reccomend depending on it directly, and instead
 using the builtin Python type annotations. This will allow us to change the implementation in the future without breaking user code.
 
+### Unwrapped functions
+
+We also support using normal python functions, either named or anonymous, as values. These will automaticalyl be wrapped as egglog functions when passed to a function which expects an egglog function.
+
+```{code-cell} python
+x = MathList.EMPTY.append(Math(1))
+added_two = x.map(lambda x: x + Math(2))
+check_eq(added_two, MathList.EMPTY.append(Math(1) + Math(2)), (math_list_ruleset + run()) * 10)
+```
+
+Their definition will be added to the default rulset, unless they are defined in the body of a function themselves or
+in a rule function:
+
+```{code-cell} python
+@function(ruleset=math_list_ruleset)
+def map_add_two(x: MathList) -> MathList:
+    return x.map(lambda x: x + Math(2))
+
+check_eq(map_add_two(MathList.EMPTY.append(Math(1))), MathList.EMPTY.append(Math(1) + Math(2)), math_list_ruleset.saturate())
+```
+
 ## Default Replacements
 
 When defining a function or a constant, you can also provide a default replacement value. This is useful when

--- a/python/egglog/examples/higher_order_functions.py
+++ b/python/egglog/examples/higher_order_functions.py
@@ -16,15 +16,12 @@ if TYPE_CHECKING:
 
 class Math(Expr):
     def __init__(self, i: i64Like) -> None: ...
-
     def __add__(self, other: Math) -> Math: ...
 
 
 class MathList(Expr):
     def __init__(self) -> None: ...
-
     def append(self, i: Math) -> MathList: ...
-
     def map(self, f: Callable[[Math], Math]) -> MathList: ...
 
 
@@ -36,15 +33,13 @@ def math_ruleset(i: i64, j: i64, xs: MathList, x: Math, f: Callable[[Math], Math
 
 
 @function(ruleset=math_ruleset)
-def increment_by_one(x: Math) -> Math:
-    return x + Math(1)
+def incr_list(xs: MathList) -> MathList:
+    return xs.map(lambda x: x + Math(1))
 
 
 egraph = EGraph()
-x = egraph.let("x", MathList().append(Math(1)).append(Math(2)))
-y = egraph.let("y", x.map(increment_by_one))
+y = egraph.let("y", incr_list(MathList().append(Math(1)).append(Math(2))))
 egraph.run(math_ruleset.saturate())
-
 egraph.check(eq(y).to(MathList().append(Math(2)).append(Math(3))))
 
 egraph

--- a/python/egglog/functionalize.py
+++ b/python/egglog/functionalize.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from functools import partial
+from inspect import Parameter, signature
+from typing import Any, TypeVar, cast
+
+__all__ = ["functionalize"]
+
+
+T = TypeVar("T", bound=Callable)
+
+
+# TODO: Add `to_lift` param so that we only transform those with vars in them to args
+
+
+def functionalize(f: T, get_annotation: Callable[[object], type | None]) -> T:
+    """
+    Takes a function and returns a new function with all names (co_names) and free variables (co_freevars) added as arguments
+    and then partially applied with their values. The second arg, get_annotation, will be applied to all values
+    to get their type annotation. If it is None, that arg will not be added as a parameter.
+
+    For example if you have:
+
+        def get_annotation(x): return int if x <= 10 else None
+
+        g = 10
+        def f(a, a2):
+            def h(b: Z):
+                return a + a2 + b + g
+
+            return functionalize(h, get_annotation)
+        res = f(9, 11)
+
+    It should be equivalent to (according to body, signature, and annotations) (Note that the new arguments will be positional only):
+
+        def h(a: get_annotation(a), g: get_annotation(g), b: Z):
+            return a + b + g
+        res = partial(h, a, g)
+    """
+    code = f.__code__
+    names = code.co_names
+    free_vars = code.co_freevars
+    names + free_vars
+
+    global_values: list[Any] = [f.__globals__[name] for name in names]
+    free_var_values = [cell.cell_contents for cell in f.__closure__] if f.__closure__ else []
+    assert len(free_var_values) == len(free_vars), "Free vars and their values do not match"
+    global_values_filtered = [
+        (i, name, value, annotation)
+        for i, (name, value) in enumerate(zip(names, global_values, strict=True))
+        if (annotation := get_annotation(value)) is not None
+    ]
+    free_var_values_filtered = [
+        (i, name, value, annotation)
+        for i, (name, value) in enumerate(zip(free_vars, free_var_values, strict=True))
+        if (annotation := get_annotation(value)) is not None
+    ]
+    additional_arg_filtered = global_values_filtered + free_var_values_filtered
+
+    # Create a wrapper function
+    def wrapper(*args):
+        # Split args into names, free vars and other args
+        name_args, free_var_args, rest_args = (
+            args[: (n_names := len(global_values_filtered))],
+            args[n_names : (n_args := len(additional_arg_filtered))],
+            args[n_args:],
+        )
+        # Update globals with names
+        f.__globals__.update({
+            name: arg for (_, name, _, _), arg in zip(global_values_filtered, name_args, strict=False)
+        })
+        # update function free vars with free var args
+        for (i, _, _, _), value in zip(free_var_values_filtered, free_var_args, strict=True):
+            assert f.__closure__, "Function does not have closure"
+            f.__closure__[i].cell_contents = value
+        return f(*rest_args)
+
+    # Set the signature of the new function to a signature with the free vars and names added as arguments
+    orig_signature = signature(f)
+    wrapper.__signature__ = orig_signature.replace(  # type: ignore[attr-defined]
+        parameters=[
+            *[Parameter(n, Parameter.POSITIONAL_OR_KEYWORD) for _, n, _, _ in additional_arg_filtered],
+            *orig_signature.parameters.values(),
+        ]
+    )
+    # Set the annotations of the new function to the annotations of the original function + annotations of passed in values
+    wrapper.__annotations__ = f.__annotations__ | {n: a for _, n, _, a in additional_arg_filtered}
+    wrapper.__name__ = f.__name__
+
+    # Partially apply the wrapper function with the current values of the free vars
+    return cast(T, partial(wrapper, *(v for _, _, v, _ in additional_arg_filtered)))

--- a/python/egglog/runtime.py
+++ b/python/egglog/runtime.py
@@ -285,7 +285,7 @@ class RuntimeFunction(DelayedDeclerations):
         args = bound.args
 
         upcasted_args = [
-            resolve_literal(cast(TypeOrVarRef, tp), arg)
+            resolve_literal(cast(TypeOrVarRef, tp), arg, Thunk.value(decls))
             for arg, tp in zip_longest(args, signature.arg_types, fillvalue=signature.var_arg_type)
         ]
         decls.update(*upcasted_args)
@@ -389,6 +389,7 @@ PARTIAL_METHODS = {
 @dataclass
 class RuntimeExpr:
     # Defer needing decls/expr so we can make constants that don't resolve their class types
+    # TODO: Refactor as two thunks, one for decls and one for expr, to make it easier to construct
     __egg_thunk__: Callable[[], tuple[Declarations, TypedExprDecl]]
 
     @classmethod

--- a/python/tests/test_functionalize.py
+++ b/python/tests/test_functionalize.py
@@ -1,0 +1,61 @@
+from collections.abc import Callable
+from functools import partial
+from inspect import signature
+from typing import get_type_hints
+
+from egglog.functionalize import functionalize
+
+
+def get_annotation(x: object) -> type | None:
+    return type(x) if x != 1 else None
+
+
+x = "x"
+
+
+def outer(y1: str, y2: int) -> Callable[[str, int], tuple[str, str, int, str, int]]:
+    def inner(z1: str, z2: int) -> tuple[str, str, int, str, int]:
+        return (x, y1, y2, z1, z2)
+
+    return functionalize(inner, get_annotation)
+
+
+res = outer("y1", 1)
+
+
+def test_partial():
+    assert isinstance(res, partial)
+    assert res.args == ("x", "y1")
+
+
+def test_signature():
+    assert isinstance(res, partial)
+
+    sig = signature(res.func)
+    assert list(sig.parameters) == ["x", "y1", "z1", "z2"]
+
+
+def test_annotations():
+    assert isinstance(res, partial)
+
+    annotations = get_type_hints(res.func)
+    assert annotations == {
+        "x": str,
+        "y1": str,
+        "z1": str,
+        "z2": int,
+        "return": tuple[str, str, int, str, int],
+    }
+
+
+def test_call():
+    assert res("z1", 2) == ("x", "y1", 1, "z1", 2)
+
+
+def test_call_again():
+    assert res("z1_", 22) == ("x", "y1", 1, "z1_", 22)
+
+
+def test_name():
+    assert isinstance(res, partial)
+    assert res.func.__name__ == "inner"


### PR DESCRIPTION
This allows you to pass a normal Python function (not decorated in @function) to higher order egglog functions.