### PR TITLE
Name anon functions based on bodys

### DIFF
--- a/docs/reference/python-integration.md
+++ b/docs/reference/python-integration.md
@@ -430,7 +430,7 @@ using the builtin Python type annotations. This will allow us to change the impl
 
 ### Unwrapped functions
 
-We also support using normal python functions, either named or anonymous, as values. These will automaticalyl be wrapped as egglog functions when passed to a function which expects an egglog function.
+We also support using normal python functions, either named or anonymous, as values. These will automatically be wrapped as egglog functions when passed to a function which expects an egglog function.
 
 ```{code-cell} python
 x = MathList.EMPTY.append(Math(1))
@@ -447,6 +447,12 @@ def map_add_two(x: MathList) -> MathList:
     return x.map(lambda x: x + Math(2))
 
 check_eq(map_add_two(MathList.EMPTY.append(Math(1))), MathList.EMPTY.append(Math(1) + Math(2)), math_list_ruleset.saturate())
+```
+
+Their name will just be the body of the function, so that two anonymous functions with the same body will be considered equal.
+
+```{code-cell} python
+added_two
 ```
 
 ## Default Replacements

--- a/python/egglog/builtins.py
+++ b/python/egglog/builtins.py
@@ -524,7 +524,9 @@ def _convert_function(a: FunctionType) -> UnstableFn:
     a.__name__ = f"{a.__name__} {hash(a.__code__)}"
     transformed_fn = functionalize(a, value_to_annotation)
     assert isinstance(transformed_fn, partial)
-    return UnstableFn(function(ruleset=get_current_ruleset())(transformed_fn.func), *transformed_fn.args)
+    return UnstableFn(
+        function(ruleset=get_current_ruleset(), use_body_as_name=True)(transformed_fn.func), *transformed_fn.args
+    )
 
 
 def value_to_annotation(a: object) -> type | None:

--- a/python/egglog/pretty.py
+++ b/python/egglog/pretty.py
@@ -244,8 +244,10 @@ class PrettyContext:
             case CallDecl(_, _, _):
                 return self._call(decl, parens)
             case PartialCallDecl(CallDecl(ref, typed_args, _)):
+                if not typed_args:
+                    return _pretty_callable(ref), "fn"
                 arg_strs = (_pretty_callable(ref), *(self(a.expr, parens=False, unwrap_lit=True) for a in typed_args))
-                return f"UnstableFn({', '.join(arg_strs)})", "fn"
+                return f"partial({', '.join(arg_strs)})", "fn"
             case PyObjectDecl(value):
                 return repr(value) if unwrap_lit else f"PyObject({value!r})", "PyObject"
             case ActionCommandDecl(action):

--- a/python/egglog/thunk.py
+++ b/python/egglog/thunk.py
@@ -9,10 +9,27 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-__all__ = ["Thunk"]
+__all__ = ["Thunk", "split_thunk"]
 
 T = TypeVar("T")
 TS = TypeVarTuple("TS")
+V = TypeVar("V")
+
+
+def split_thunk(fn: Callable[[], tuple[T, V]]) -> tuple[Callable[[], T], Callable[[], V]]:
+    s = _Split(fn)
+    return s.left, s.right
+
+
+@dataclass
+class _Split(Generic[T, V]):
+    fn: Callable[[], tuple[T, V]]
+
+    def left(self) -> T:
+        return self.fn()[0]
+
+    def right(self) -> V:
+        return self.fn()[1]
 
 
 @dataclass

--- a/python/tests/test_runtime.py
+++ b/python/tests/test_runtime.py
@@ -30,7 +30,7 @@ def test_function_call():
             "one": FunctionDecl(FunctionSignature(return_type=TypeRefWithVars("i64"))),
         },
     )
-    one = RuntimeFunction(Thunk.value(decls), FunctionRef("one"))
+    one = RuntimeFunction(Thunk.value(decls), Thunk.value(FunctionRef("one")))
     assert (
         one().__egg_typed_expr__  # type: ignore[union-attr]
         == TypedExprDecl(JustTypeRef("i64"), CallDecl(FunctionRef("one")))

--- a/python/tests/test_unstable_fn.py
+++ b/python/tests/test_unstable_fn.py
@@ -68,11 +68,11 @@ def test_call_fn():
 
 
 def test_string_fn():
-    assert str(UnstableFn(square)) == "UnstableFn(square)"
+    assert str(UnstableFn(square)) == "square"
 
 
 def test_string_fn_partial():
-    assert str(UnstableFn(Math.__mul__, Math(2))) == "UnstableFn(Math.__mul__, Math(2))"
+    assert str(UnstableFn(Math.__mul__, Math(2))) == "partial(Math.__mul__, Math(2))"
 
 
 @ruleset
@@ -319,3 +319,13 @@ class TestNormalFns:
         egraph.run(10)
         egraph.check(eq(x).to(A()))
         egraph.check(eq(y).to(alt_a))
+
+    def test_name_is_body(self):
+        @function
+        def higher_order(f: Callable[[A], A]) -> A: ...
+
+        @function
+        def transform_a(a: A) -> A: ...
+
+        v = higher_order(lambda a: transform_a(a))
+        assert str(v) == "higher_order(lambda a: transform_a(a))"


### PR DESCRIPTION
This PR makes unwrapped functions be named as their bodies, instead of assigning a unique ID to them.

This makes it easier to see them in the graph view and makes them de-duplicate based on the body. See https://egraphs.zulipchat.com/#narrow/stream/375765-egg.2Fegglog/topic/Anonymous.20Functions.20in.20Egglog for more details.