### PR TITLE
arm matrix

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -45,6 +45,29 @@ jobs:
           TYPE: ${{ inputs.type }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  linux-cross:
+    name: build linux
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [aarch64, ppc64]
+    needs: [bump]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: version-${{ needs.bump.outputs.version }}
+      - uses: PyO3/maturin-action@v1.42.1
+        with:
+          target: ${{ matrix.target }}
+          manylinux: auto
+          command: build
+          args: --release --sdist -o dist --find-interpreter
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-linux
+          path: dist
+
   linux:
     name: build linux
     runs-on: ubuntu-latest
@@ -104,7 +127,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch')
-    needs: [macos, windows, linux]
+    needs: [macos, windows, linux, linux-cross]
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Having done some digging, the various wheels published to pypy don't include arm (Linux). This is my fault.

Looking at [this example](https://github.com/messense/crfs-rs/blob/b118948df13e3d3b1ea8dc73e3088319e5f02b04/.github/workflows/Python.yml#L96), it appears rather different than the documented change we made in #199.

Sorry about this @saulshanabrook. Hope this helps.