### PR TITLE
Python 3.13 Trove and CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,6 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         py:
+          - "3.13"
           - "3.12"
           - "3.11"
           - "3.10"
@@ -36,6 +37,7 @@ jobs:
           python-version: ${{ matrix.py }}
       - run: uv sync --extra test --locked
       - run: uv run pytest --benchmark-disable -vvv
+
   mypy:
     runs-on: ubuntu-latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
@@ -33,7 +34,7 @@ array = [
     "scikit-learn",
     "array_api_compat",
     "numba==0.59.1",
-    "llvmlite==0.42.0",
+    "llvmlite==0.43.0",
 ]
 dev = [
     "ruff",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ array = [
     "scikit-learn",
     "array_api_compat",
     "numba==0.59.1",
-    "llvmlite==0.43.0",
+    "llvmlite==0.42.0",
 ]
 dev = [
     "ruff",


### PR DESCRIPTION
Given the quick read I'd done of the dependencies, it appears that this library should work on python 3.13. I went for a very lazy CI change and adding the trove, thinking that if this passes, it might be useful to others.

Similarly, if this fails, by all means kill the PR :D