### PR TITLE
CallDecl __eq__ Fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "maturin"
 name = "egglog"
 description = "e-graphs in Python built around the the egglog rust library"
 readme = "README.md"
+dynamic = ["version"]
 license = { text = "MIT" }
 requires-python = ">=3.10"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 name = "egglog"
 description = "e-graphs in Python built around the the egglog rust library"
 readme = "README.md"
-dynamic = ["version"]
+dynamic = ["version"] 
 license = { text = "MIT" }
 requires-python = ">=3.10"
 classifiers = [

--- a/python/egglog/declarations.py
+++ b/python/egglog/declarations.py
@@ -570,10 +570,9 @@ class CallDecl:
         return hash((self.callable, self.args, self.bound_tp_params))
 
     def __eq__(self, other: object) -> bool:
-        # Override eq to use cached hash for perf
-        if not isinstance(other, CallDecl):
+        if not isinstance(other, egglog.declarations.CallDecl):
             return False
-        return hash(self) == hash(other)
+        return self.callable == other.callable and self.args == other.args and self.bound_tp_params == other.bound_tp_params
 
 
 @dataclass(frozen=True)

--- a/python/egglog/declarations.py
+++ b/python/egglog/declarations.py
@@ -575,8 +575,11 @@ class CallDecl:
             return False
         if hash(self) != hash(other):
             return False
-        return self.callable == other.callable and self.args == other.args and self.bound_tp_params == other.bound_tp_params
-
+        return (
+            self.callable == other.callable
+            and self.args == other.args
+            and self.bound_tp_params == other.bound_tp_params
+        )
 
 
 @dataclass(frozen=True)

--- a/python/egglog/declarations.py
+++ b/python/egglog/declarations.py
@@ -570,7 +570,7 @@ class CallDecl:
         return hash((self.callable, self.args, self.bound_tp_params))
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, egglog.declarations.CallDecl):
+        if not isinstance(other, CallDecl):
             return False
         return self.callable == other.callable and self.args == other.args and self.bound_tp_params == other.bound_tp_params
 

--- a/python/egglog/declarations.py
+++ b/python/egglog/declarations.py
@@ -570,9 +570,13 @@ class CallDecl:
         return hash((self.callable, self.args, self.bound_tp_params))
 
     def __eq__(self, other: object) -> bool:
+        # Override eq to use cached hash for perf
         if not isinstance(other, CallDecl):
             return False
+        if hash(self) != hash(other):
+            return False
         return self.callable == other.callable and self.args == other.args and self.bound_tp_params == other.bound_tp_params
+
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Fixes #244, As suggested this fixes the problem of hash collisions (and specifically the `hash(-1) == hash(-2)` case).
Benchmark shows no change for either the original suggested change or the slightly more optimized one, but it seems reasonable to use it in the improved form.
There is also a change to the pyproject.toml - adding a version, which seemed required to get the CI to work for me