### PR TITLE
Fix python 3.13 support

### DIFF
--- a/python/egglog/egraph.py
+++ b/python/egglog/egraph.py
@@ -114,6 +114,8 @@ IGNORED_ATTRIBUTES = {
     "__annotations__",
     "__hash__",
     "__qualname__",
+    "__firstlineno__",
+    "__static_attributes__",
     # Ignore all reflected binary method
     *REFLECTED_BINARY_METHODS.keys(),
 }

--- a/python/egglog/runtime.py
+++ b/python/egglog/runtime.py
@@ -229,6 +229,7 @@ class RuntimeClass(DelayedDeclerations):
             # Origin is used in get_type_hints which is used when resolving the class itself
             "__origin__",
             "__typing_unpacked_tuple_args__",
+            "__typing_is_unpacked_typevartuple__",
         }:
             raise AttributeError
 


### PR DESCRIPTION
Hi,

I just upgraded to python 3.13, and noticed that the library threw some exceptions on start up. After a bit of digging, I reached these ignore lists for reflected attributes, and added the offending ones which were added in python 3.13.

I'm actually not sure why it failed for me and the CI tests for python 3.13 seem to pass, if you can shed some light on that?
(edit: in fact, I'm also not sure how python 3.10 tests pass, since egraph.py:20 imports typing.Never which is introduced in 3.11?)

Let me know if I got it right, I'm not sure I understand the entire runtime 😄
