### PR TITLE
More accurate local benchmarking

### DIFF
--- a/python/tests/test_array_api.py
+++ b/python/tests/test_array_api.py
@@ -412,7 +412,7 @@ class TestLDA:
         y = NDArray.var("y")
         with egraph.set_current():
             expr = lda(X, y)
-            simplified = benchmark.pendatic(simplify_lda, args=(egraph, expr))
+            simplified = benchmark.pedantic(simplify_lda, args=(egraph, expr))
         assert str(simplified) == snapshot_py
 
     # @pytest.mark.xfail(reason="Original source is not working")

--- a/python/tests/test_array_api.py
+++ b/python/tests/test_array_api.py
@@ -412,7 +412,7 @@ class TestLDA:
         y = NDArray.var("y")
         with egraph.set_current():
             expr = lda(X, y)
-            simplified = benchmark(simplify_lda, egraph, expr)
+            simplified = benchmark.pendatic(simplify_lda, args=(egraph, expr))
         assert str(simplified) == snapshot_py
 
     # @pytest.mark.xfail(reason="Original source is not working")


### PR DESCRIPTION
This PR simplifies the current benchmarks and makes them more accurate, so that if they are run in multiple iterations things won't be improperly cached.