### PR TITLE
Add multiset, bigint, bigrat builtins

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,6 +27,7 @@ _This project uses semantic versioning_
 - Removes `eval` method from `EGraph` and moves primitive evaluation to methods on each builtin and support `int(...)` type conversions on primitives. [#265](https://github.com/egraphs-good/egglog-python/pull/265)
 - Change how to set global EGraph context with `with egraph.set_current()` and `EGraph.current` and add support for setting global schedule as well with `with schedule.set_current()` and `Schedule.current`. [#265](https://github.com/egraphs-good/egglog-python/pull/265)
 - Adds support for using `==` and `!=` directly on values instead of `eq` and `ne` functions. [#265](https://github.com/egraphs-good/egglog-python/pull/265)
+- Add multiset, bigint, and bigrat builtins
 
 ## 8.0.1 (2024-10-24)
 

--- a/python/egglog/declarations.py
+++ b/python/egglog/declarations.py
@@ -475,6 +475,8 @@ class FunctionSignature:
     # If None, then the first arg is mutated and returned
     return_type: TypeOrVarRef | None = None
     var_arg_type: TypeOrVarRef | None = None
+    # Whether to reverse args when emitting to egglog
+    reverse_args: bool = False
 
     @property
     def semantic_return_type(self) -> TypeOrVarRef:
@@ -588,7 +590,7 @@ class CallDecl:
 
         normalized_args = (callable, args_, bound_tp_params)
         try:
-            return cast(Self, cls._args_to_value[normalized_args])
+            return cast("Self", cls._args_to_value[normalized_args])
         except KeyError:
             res = super().__new__(cls)
             cls._args_to_value[normalized_args] = res

--- a/python/egglog/examples/bignum.py
+++ b/python/egglog/examples/bignum.py
@@ -1,0 +1,31 @@
+# mypy: disable-error-code="empty-body"
+"""
+BigNum/BigRat Example
+=====================
+"""
+
+from __future__ import annotations
+
+from egglog import *
+
+x = BigInt(-1234)
+y = BigInt.from_string("2")
+z = BigRat(x, y)
+
+assert z.numer.to_string() == "-617"
+
+
+@function
+def bignums(x: BigInt, y: BigInt) -> BigRat: ...
+
+
+egraph = EGraph()
+egraph.register(set_(bignums(x, y)).to(z))
+
+c = var("c", BigRat)
+a, b = vars_("a b", BigInt)
+egraph.check(
+    bignums(a, b) == c,
+    c.numer == a >> 1,
+    c.denom == b >> 1,
+)

--- a/python/egglog/examples/multiset.py
+++ b/python/egglog/examples/multiset.py
@@ -1,0 +1,61 @@
+# mypy: disable-error-code="empty-body"
+"""
+Multiset example based off of egglog version
+============================================
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from egglog import *
+
+
+class Math(Expr):
+    def __init__(self, x: i64Like) -> None: ...
+
+
+@function
+def square(x: Math) -> Math: ...
+
+
+@ruleset
+def math_ruleset(i: i64):
+    yield rewrite(square(Math(i))).to(Math(i * i))
+
+
+egraph = EGraph()
+
+xs = MultiSet(Math(1), Math(2), Math(3))
+egraph.register(xs)
+
+with egraph.set_current():
+    assert xs == MultiSet(Math(1), Math(3), Math(2))
+    assert xs != MultiSet(Math(1), Math(1), Math(2), Math(3))
+
+    assert Counter(xs) == Counter({Math(1): 1, Math(2): 1, Math(3): 1})
+
+    inserted = MultiSet(Math(1), Math(2), Math(3), Math(4))
+    egraph.register(inserted)
+    assert xs.insert(Math(4)) == inserted
+
+    assert xs.contains(Math(1))
+    assert xs.not_contains(Math(4))
+    assert Math(1) in xs
+    assert Math(4) not in xs
+
+    assert xs.remove(Math(1)) == MultiSet(Math(2), Math(3))
+
+    assert xs.length() == i64(3)
+    assert len(xs) == 3
+
+    assert MultiSet(Math(1), Math(1)).length() == i64(2)
+
+    assert MultiSet(Math(1)).pick() == Math(1)
+
+    mapped = xs.map(square)
+    egraph.register(mapped)
+    egraph.run(math_ruleset)
+    assert mapped == MultiSet(Math(1), Math(4), Math(9))
+
+    assert xs + xs == MultiSet(Math(1), Math(2), Math(3), Math(1), Math(2), Math(3))

--- a/python/tests/test_high_level.py
+++ b/python/tests/test_high_level.py
@@ -531,6 +531,16 @@ class TestEval:
         o = object()
         assert PyObject(o).eval() is o
 
+    def test_big_int(self):
+        assert int(BigInt(10)) == 10
+
+    def test_big_rat(self):
+        assert float(BigRat(1, 2)) == 1 / 2
+        assert BigRat(1, 2).eval() == Fraction(1, 2)
+
+    def test_multiset(self):
+        assert list(MultiSet(i64(1), i64(1))) == [i64(1), i64(1)]
+
 
 # def test_egglog_string():
 #     egraph = EGraph(save_egglog_string=True)

--- a/python/tests/test_type_constraint_solver.py
+++ b/python/tests/test_type_constraint_solver.py
@@ -14,47 +14,40 @@ decls = Declarations(_classes={"Map": ClassDecl(type_vars=(K, V))})
 
 
 def test_simple() -> None:
-    assert (
-        TypeConstraintSolver(Declarations()).infer_return_type([i64.to_var()], i64.to_var(), None, [i64], None) == i64
-    )
+    tcs = TypeConstraintSolver(Declarations())
+    tcs.infer_typevars(i64.to_var(), i64)
+    assert tcs.substitute_typevars(i64.to_var()) == i64
 
 
 def test_wrong_arg() -> None:
+    tcs = TypeConstraintSolver(Declarations())
     with pytest.raises(TypeConstraintError):
-        TypeConstraintSolver(Declarations()).infer_return_type([i64.to_var()], i64.to_var(), None, [unit], None)
-
-
-def test_wrong_number_args() -> None:
-    with pytest.raises(TypeConstraintError):
-        TypeConstraintSolver(Declarations()).infer_return_type([], i64.to_var(), None, [unit], "Map")
+        tcs.infer_typevars(i64.to_var(), unit)
 
 
 def test_generic() -> None:
-    assert TypeConstraintSolver(decls).infer_return_type([map, K], V, None, [map_i64_unit, i64], "Map") == unit
+    tcs = TypeConstraintSolver(Declarations())
+    tcs.infer_typevars(map, map_i64_unit, "Map")
+    tcs.infer_typevars(K, i64, "Map")
+    assert tcs.substitute_typevars(V, "Map") == unit
 
 
 def test_generic_wrong() -> None:
+    tcs = TypeConstraintSolver(Declarations())
+    tcs.infer_typevars(map, map_i64_unit, "Map")
     with pytest.raises(TypeConstraintError):
-        TypeConstraintSolver(decls).infer_return_type([map, K], V, None, [map_i64_unit, unit], "Map")
-
-
-def test_variable() -> None:
-    assert TypeConstraintSolver(decls).infer_return_type([map, K], V, V, [map_i64_unit, i64, unit, unit], "Map") == unit
-
-
-def test_variable_wrong() -> None:
-    with pytest.raises(TypeConstraintError):
-        TypeConstraintSolver(decls).infer_return_type([map, K], V, V, [map_i64_unit, i64, unit, i64], "Map")
+        tcs.infer_typevars(K, unit, "Map")
 
 
 def test_bound() -> None:
     bound_cs = TypeConstraintSolver(decls)
     bound_cs.bind_class(map_i64_unit)
-    assert bound_cs.infer_return_type([K], V, None, [i64], "Map") == unit
+    bound_cs.infer_typevars(K, i64, "Map")
+    assert bound_cs.substitute_typevars(V, "Map") == unit
 
 
 def test_bound_wrong():
     bound_cs = TypeConstraintSolver(decls)
     bound_cs.bind_class(map_i64_unit)
     with pytest.raises(TypeConstraintError):
-        bound_cs.infer_return_type([K], V, None, [unit], "Map")
+        bound_cs.infer_typevars(K, unit, "Map")


### PR DESCRIPTION
Adds bindings for new builtins. This required some generalizations to the current type resolver to support the `map` function on multisets