### PR TITLE
Easily create pure egglog output of jitted function

### DIFF
--- a/python/egglog/egraph.py
+++ b/python/egglog/egraph.py
@@ -1241,10 +1241,10 @@ class EGraph:
 
     def _register_commands(self, cmds: list[Command]) -> None:
         self._add_decls(*cmds)
-        egg_cmds = list(map(self._command_to_egg, cmds))
+        egg_cmds = [egg_cmd for cmd in cmds if (egg_cmd := self._command_to_egg(cmd)) is not None]
         self._egraph.run_program(*egg_cmds)
 
-    def _command_to_egg(self, cmd: Command) -> bindings._Command:
+    def _command_to_egg(self, cmd: Command) -> bindings._Command | None:
         ruleset_name = ""
         cmd_decl: CommandDecl
         match cmd:

--- a/python/egglog/exp/array_api_jit.py
+++ b/python/egglog/exp/array_api_jit.py
@@ -2,10 +2,14 @@ import inspect
 from collections.abc import Callable
 from typing import TypeVar, cast
 
+import numpy as np
+
 from egglog import EGraph, try_evaling
 from egglog.exp.array_api import NDArray
 from egglog.exp.array_api_numba import array_api_numba_schedule
-from egglog.exp.array_api_program_gen import array_api_program_gen_schedule, ndarray_function_two
+from egglog.exp.array_api_program_gen import EvalProgram, array_api_program_gen_schedule, ndarray_function_two_program
+
+from .program_gen import Program
 
 X = TypeVar("X", bound=Callable)
 
@@ -14,15 +18,27 @@ def jit(fn: X) -> X:
     """
     Jit compiles a function
     """
-    sig = inspect.signature(fn)
-    arg1, arg2 = sig.parameters.keys()
-    egraph = EGraph()
+    egraph, res, res_optimized, program = function_to_program(fn, save_egglog_string=False)
+    fn_program = EvalProgram(program, {"np": np})
     with egraph.set_current():
-        res = fn(NDArray.var(arg1), NDArray.var(arg2))
-    res_optimized = egraph.simplify(res, array_api_numba_schedule)
-
-    fn_program = ndarray_function_two(res_optimized, NDArray.var(arg1), NDArray.var(arg2))
-    fn = try_evaling(array_api_program_gen_schedule, fn_program, fn_program.as_py_object)
+        fn = cast("X", try_evaling(array_api_program_gen_schedule, fn_program, fn_program.as_py_object))
     fn.initial_expr = res  # type: ignore[attr-defined]
     fn.expr = res_optimized  # type: ignore[attr-defined]
-    return cast(X, fn)
+    return fn
+
+
+def function_to_program(fn: Callable, save_egglog_string: bool) -> tuple[EGraph, NDArray, NDArray, Program]:
+    sig = inspect.signature(fn)
+    arg1, arg2 = sig.parameters.keys()
+    egraph = EGraph(save_egglog_string=save_egglog_string)
+    with egraph:
+        with egraph.set_current():
+            res = fn(NDArray.var(arg1), NDArray.var(arg2))
+        res_optimized = egraph.simplify(res, array_api_numba_schedule)
+
+    return (
+        egraph,
+        res,
+        res_optimized,
+        ndarray_function_two_program(res_optimized, NDArray.var(arg1), NDArray.var(arg2)),
+    )

--- a/python/egglog/exp/array_api_program_gen.py
+++ b/python/egglog/exp/array_api_program_gen.py
@@ -14,13 +14,13 @@ from .program_gen import *
 array_api_program_gen_ruleset = ruleset(name="array_api_program_gen_ruleset")
 array_api_program_gen_eval_ruleset = ruleset(name="array_api_program_gen_eval_ruleset")
 
-array_api_program_gen_schedule = (
+array_api_program_gen_combined_ruleset = (
     array_api_program_gen_ruleset
     | program_gen_ruleset
     | array_api_program_gen_eval_ruleset
-    | eval_program_rulseset
     | array_api_vec_to_cons_ruleset
-).saturate()
+)
+array_api_program_gen_schedule = (array_api_program_gen_combined_ruleset | eval_program_rulseset).saturate()
 
 
 @function
@@ -116,7 +116,7 @@ def float_program(x: Float) -> Program: ...
 
 
 @array_api_program_gen_ruleset.register
-def _float_program(f: Float, g: Float, f64_: f64, i: Int, r: Rational):
+def _float_program(f: Float, g: Float, f64_: f64, i: Int, r: BigRat):
     yield rewrite(float_program(Float(f64_))).to(Program(f64_.to_string()))
     yield rewrite(float_program(f.abs())).to(Program("np.abs(") + float_program(f) + ")")
     yield rewrite(float_program(Float.from_int(i))).to(int_program(i))
@@ -126,10 +126,10 @@ def _float_program(f: Float, g: Float, f64_: f64, i: Int, r: Rational):
     yield rewrite(float_program(f / g)).to(Program("(") + float_program(f) + " / " + float_program(g) + ")")
     yield rewrite(float_program(Float.rational(r))).to(
         Program("float(") + Program(r.numer.to_string()) + " / " + Program(r.denom.to_string()) + ")",
-        ne(r.denom).to(i64(1)),
+        ne(r.denom).to(BigInt(1)),
     )
     yield rewrite(float_program(Float.rational(r))).to(
-        Program("float(") + Program(r.numer.to_string()) + ")", eq(r.denom).to(i64(1))
+        Program("float(") + Program(r.numer.to_string()) + ")", eq(r.denom).to(BigInt(1))
     )
 
 

--- a/python/tests/__snapshots__/test_array_api/test_jit[lda][expr].py
+++ b/python/tests/__snapshots__/test_array_api/test_jit[lda][expr].py
@@ -17,7 +17,7 @@ _NDArray_3 = astype(
         )
     ),
     DType.float64,
-) / NDArray.scalar(Value.float(Float.rational(Rational(150, 1))))
+) / NDArray.scalar(Value.float(Float.rational(BigRat(BigInt.from_string("150"), BigInt.from_string("1")))))
 _NDArray_4 = zeros(TupleInt.from_vec(Vec[Int](Int(3), Int(4))), OptionalDType.some(DType.float64), OptionalDevice.some(_NDArray_1.device))
 _MultiAxisIndexKeyItem_1 = MultiAxisIndexKeyItem.slice(Slice())
 _IndexKey_1 = IndexKey.multi_axis(MultiAxisIndexKey.from_vec(Vec[MultiAxisIndexKeyItem](MultiAxisIndexKeyItem.int(Int(0)), _MultiAxisIndexKeyItem_1)))
@@ -36,15 +36,24 @@ _NDArray_8 = concat(
 _NDArray_9 = square(_NDArray_8 - expand_dims(sum(_NDArray_8, _OptionalIntOrTuple_1) / NDArray.scalar(Value.int(_NDArray_8.shape[Int(0)]))))
 _NDArray_10 = sqrt(sum(_NDArray_9, _OptionalIntOrTuple_1) / NDArray.scalar(Value.int(_NDArray_9.shape[Int(0)])))
 _NDArray_11 = copy(_NDArray_10)
-_NDArray_11[IndexKey.ndarray(_NDArray_10 == NDArray.scalar(Value.int(Int(0))))] = NDArray.scalar(Value.float(Float.rational(Rational(1, 1))))
-_TupleNDArray_1 = svd(sqrt(asarray(NDArray.scalar(Value.float(Float.rational(Rational(1, 147)))), OptionalDType.some(DType.float64))) * (_NDArray_8 / _NDArray_11), Boolean(False))
+_NDArray_11[IndexKey.ndarray(_NDArray_10 == NDArray.scalar(Value.int(Int(0))))] = NDArray.scalar(
+    Value.float(Float.rational(BigRat(BigInt.from_string("1"), BigInt.from_string("1"))))
+)
+_TupleNDArray_1 = svd(
+    sqrt(asarray(NDArray.scalar(Value.float(Float.rational(BigRat(BigInt.from_string("1"), BigInt.from_string("147"))))), OptionalDType.some(DType.float64)))
+    * (_NDArray_8 / _NDArray_11),
+    Boolean(False),
+)
 _Slice_1 = Slice(OptionalInt.none, OptionalInt.some(sum(astype(_TupleNDArray_1[Int(1)] > NDArray.scalar(Value.float(Float(0.0001))), DType.int32)).to_value().to_int))
 _NDArray_12 = (
     _TupleNDArray_1[Int(2)][IndexKey.multi_axis(MultiAxisIndexKey.from_vec(Vec[MultiAxisIndexKeyItem](MultiAxisIndexKeyItem.slice(_Slice_1), _MultiAxisIndexKeyItem_1)))]
     / _NDArray_11
 ).T / _TupleNDArray_1[Int(1)][IndexKey.slice(_Slice_1)]
 _TupleNDArray_2 = svd(
-    (sqrt((NDArray.scalar(Value.int(Int(150))) * _NDArray_3) * NDArray.scalar(Value.float(Float.rational(Rational(1, 2))))) * (_NDArray_4 - (_NDArray_3 @ _NDArray_4)).T).T
+    (
+        sqrt((NDArray.scalar(Value.int(Int(150))) * _NDArray_3) * NDArray.scalar(Value.float(Float.rational(BigRat(BigInt.from_string("1"), BigInt.from_string("2"))))))
+        * (_NDArray_4 - (_NDArray_3 @ _NDArray_4)).T
+    ).T
     @ _NDArray_12,
     Boolean(False),
 )

--- a/python/tests/__snapshots__/test_array_api/test_jit[lda][initial_expr].py
+++ b/python/tests/__snapshots__/test_array_api/test_jit[lda][initial_expr].py
@@ -41,8 +41,14 @@ _NDArray_5 = concat(
     OptionalInt.some(Int(0)),
 )
 _NDArray_6 = std(_NDArray_5, _OptionalIntOrTuple_1)
-_NDArray_6[IndexKey.ndarray(std(_NDArray_5, _OptionalIntOrTuple_1) == NDArray.scalar(Value.int(Int(0))))] = NDArray.scalar(Value.float(Float.rational(Rational(1, 1))))
-_TupleNDArray_1 = svd(sqrt(asarray(NDArray.scalar(Value.float(Float.rational(Rational(1, 147)))), OptionalDType.some(DType.float64))) * (_NDArray_5 / _NDArray_6), Boolean(False))
+_NDArray_6[IndexKey.ndarray(std(_NDArray_5, _OptionalIntOrTuple_1) == NDArray.scalar(Value.int(Int(0))))] = NDArray.scalar(
+    Value.float(Float.rational(BigRat(BigInt.from_string("1"), BigInt.from_string("1"))))
+)
+_TupleNDArray_1 = svd(
+    sqrt(asarray(NDArray.scalar(Value.float(Float.rational(BigRat(BigInt.from_string("1"), BigInt.from_string("147"))))), OptionalDType.some(DType.float64)))
+    * (_NDArray_5 / _NDArray_6),
+    Boolean(False),
+)
 _Slice_1 = Slice(OptionalInt.none, OptionalInt.some(sum(astype(_TupleNDArray_1[Int(1)] > NDArray.scalar(Value.float(Float(0.0001))), DType.int32)).to_value().to_int))
 _NDArray_7 = asarray(reshape(asarray(_NDArray_2), TupleInt.from_vec(Vec[Int](Int(-1)))))
 _NDArray_8 = unique_values(concat(TupleNDArray.from_vec(Vec[NDArray](unique_values(asarray(_NDArray_7))))))
@@ -61,9 +67,12 @@ _NDArray_9 = std(
 )
 _NDArray_10 = copy(_NDArray_9)
 _NDArray_10[IndexKey.ndarray(_NDArray_9 == NDArray.scalar(Value.int(Int(0))))] = NDArray.scalar(Value.float(Float(1.0)))
-_NDArray_11 = astype(unique_counts(_NDArray_2)[Int(1)], DType.float64) / NDArray.scalar(Value.float(Float.rational(Rational(150, 1))))
+_NDArray_11 = astype(unique_counts(_NDArray_2)[Int(1)], DType.float64) / NDArray.scalar(Value.float(Float.rational(BigRat(BigInt.from_string("150"), BigInt.from_string("1")))))
 _TupleNDArray_2 = svd(
-    (sqrt((NDArray.scalar(Value.int(Int(150))) * _NDArray_11) * NDArray.scalar(Value.float(Float.rational(Rational(1, 2))))) * (_NDArray_4 - (_NDArray_11 @ _NDArray_4)).T).T
+    (
+        sqrt((NDArray.scalar(Value.int(Int(150))) * _NDArray_11) * NDArray.scalar(Value.float(Float.rational(BigRat(BigInt.from_string("1"), BigInt.from_string("2"))))))
+        * (_NDArray_4 - (_NDArray_11 @ _NDArray_4)).T
+    ).T
     @ (
         (
             _TupleNDArray_1[Int(2)][IndexKey.multi_axis(MultiAxisIndexKey.from_vec(Vec[MultiAxisIndexKeyItem](MultiAxisIndexKeyItem.slice(_Slice_1), _MultiAxisIndexKeyItem_1)))]

--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -68,13 +68,16 @@ impl EGraph {
             cmds_str = cmds_str + &cmd.to_string() + "\n";
         }
         info!("Running commands:\n{}", cmds_str);
-        if let Some(cmds) = &mut self.cmds {
-            cmds.push_str(&cmds_str);
-        }
 
-        self.egraph.run_program(commands).map_err(|e| {
+        let res = self.egraph.run_program(commands).map_err(|e| {
             WrappedError::Egglog(e, "\nWhen running commands:\n".to_string() + &cmds_str)
-        })
+        });
+        if res.is_ok() {
+            if let Some(cmds) = &mut self.cmds {
+                cmds.push_str(&cmds_str);
+            }
+        }
+        res
     }
 
     /// Returns the text of the commands that have been run so far, if `record` was passed.


### PR DESCRIPTION
This PR changes the logic for jitting a little bit so that we can easily emit egglog source code that doesn't contain any pyobject or Rational calls. That way it can be used in upstream core egglog as a benchmark