### PR TITLE
Remove automatic extraction in builtin evaluation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "egglog_python"
-version = "9.0.0"
+version = "9.0.1"
 dependencies = [
  "egglog",
  "egglog-experimental",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,8 @@ _This project uses semantic versioning_
 
 ## UNRELEASED
 
+- Change builtins to not evaluate values in egraph and changes facts to compare structural equality instead of using an egraph when converting to a boolean, removing magic context (`EGraph.current` and `Schedule.current`) that was added in release 9.0.0.
+
 ## 9.0.1 (2025-03-20)
 
 - Add missing i64.log2 method to the bindings

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@ _This project uses semantic versioning_
 ## UNRELEASED
 
 - Change builtins to not evaluate values in egraph and changes facts to compare structural equality instead of using an egraph when converting to a boolean, removing magic context (`EGraph.current` and `Schedule.current`) that was added in release 9.0.0.
+- Fix bug that improperly upcasted values for ==
 
 ## 9.0.1 (2025-03-20)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ def _num_rule(a: Num, b: Num, c: Num, i: i64, j: i64):
     yield rewrite(Num(i) * Num(j)).to(Num(i * j))
 
 egraph.saturate()
-egraph.check(eq(expr1).to(expr2))
+egraph.check(expr1 == expr2)
 egraph.extract(expr1)
 ```
 

--- a/python/egglog/__init__.py
+++ b/python/egglog/__init__.py
@@ -3,6 +3,7 @@ Package for creating e-graphs in Python.
 """
 
 from . import config, ipython_magic  # noqa: F401
+from .bindings import EggSmolError  # noqa: F401
 from .builtins import *  # noqa: UP029
 from .conversion import ConvertError, convert, converter, get_type_args  # noqa: F401
 from .egraph import *

--- a/python/egglog/conversion.py
+++ b/python/egglog/conversion.py
@@ -149,6 +149,12 @@ def min_convertable_tp(a: object, b: object, name: str) -> JustTypeRef:
     decls = _retrieve_conversion_decls()
     a_tp = _get_tp(a)
     b_tp = _get_tp(b)
+    # Make sure at least one of the types has the method, to avoid issue with == upcasting improperly
+    if not (
+        (isinstance(a_tp, JustTypeRef) and decls.has_method(a_tp.name, name))
+        or (isinstance(b_tp, JustTypeRef) and decls.has_method(b_tp.name, name))
+    ):
+        raise ConvertError(f"Neither {a_tp} nor {b_tp} has method {name}")
     a_converts_to = {
         to: c for ((from_, to), (c, _)) in CONVERSIONS.items() if from_ == a_tp and decls.has_method(to.name, name)
     }

--- a/python/egglog/egraph.py
+++ b/python/egglog/egraph.py
@@ -848,7 +848,7 @@ class EGraph:
     seminaive: InitVar[bool] = True
     save_egglog_string: InitVar[bool] = False
 
-    _state: EGraphState = field(init=False)
+    _state: EGraphState = field(init=False, repr=False)
     # For pushing/popping with egglog
     _state_stack: list[EGraphState] = field(default_factory=list, repr=False)
     # For storing the global "current" egraph

--- a/python/egglog/egraph.py
+++ b/python/egglog/egraph.py
@@ -4,7 +4,7 @@ import contextlib
 import inspect
 import pathlib
 import tempfile
-from collections.abc import Callable, Generator, Iterable, Iterator
+from collections.abc import Callable, Generator, Iterable
 from contextvars import ContextVar
 from dataclasses import InitVar, dataclass, field
 from functools import partial
@@ -17,7 +17,6 @@ from typing import (
     Generic,
     Literal,
     Never,
-    Protocol,
     TypeAlias,
     TypedDict,
     TypeVar,
@@ -85,7 +84,6 @@ __all__ = [
     "set_",
     "simplify",
     "subsume",
-    "try_evaling",
     "union",
     "unstable_combine_rulesets",
     "var",
@@ -847,7 +845,6 @@ class EGraph:
     Can run actions, check facts, run schedules, or extract minimal cost expressions.
     """
 
-    current: ClassVar[EGraph | None] = None
     seminaive: InitVar[bool] = True
     save_egglog_string: InitVar[bool] = False
 
@@ -1200,16 +1197,6 @@ class EGraph:
             if visualize:
                 VisualizerWidget(egraphs=egraphs).display_or_open()
 
-    @contextlib.contextmanager
-    def set_current(self) -> Iterator[None]:
-        """
-        Context manager that will set the current egraph. It will be set back after.
-        """
-        prev_current = EGraph.current
-        EGraph.current = self
-        yield
-        EGraph.current = prev_current
-
     @property
     def _egraph(self) -> bindings.EGraph:
         return self._state.egraph
@@ -1303,8 +1290,6 @@ class Schedule(DelayedDeclerations):
     A composition of some rulesets, either composing them sequentially, running them repeatedly, running them till saturation, or running until some facts are met
     """
 
-    current: ClassVar[Schedule | None] = None
-
     # Defer declerations so that we can have rule generators that used not yet defined yet
     schedule: ScheduleDecl
 
@@ -1331,16 +1316,6 @@ class Schedule(DelayedDeclerations):
         Run two schedules in sequence.
         """
         return Schedule(Thunk.fn(Declarations.create, self, other), SequenceDecl((self.schedule, other.schedule)))
-
-    @contextlib.contextmanager
-    def set_current(self) -> Iterator[None]:
-        """
-        Context manager that will set the current schedule. It will be set back after
-        """
-        prev_current = Schedule.current
-        Schedule.current = self
-        yield
-        Schedule.current = prev_current
 
 
 @dataclass
@@ -1488,9 +1463,12 @@ class Fact:
 
     def __bool__(self) -> bool:
         """
-        Returns True if the two sides of an equality are equal in the egraph or the expression is in the egraph.
+        Returns True if the two sides of an equality are structurally equal.
         """
-        return (EGraph.current or EGraph()).check_bool(self)
+        if not isinstance(self.fact, EqDecl):
+            msg = "Can only check equality facts"
+            raise TypeError(msg)
+        return self.fact.left == self.fact.right
 
 
 @dataclass
@@ -1876,34 +1854,3 @@ def set_current_ruleset(r: Ruleset | None) -> Generator[None, None, None]:
         yield
     finally:
         _CURRENT_RULESET.reset(token)
-
-
-T_co = TypeVar("T_co", covariant=True)
-
-
-class _EvalsTo(Protocol, Generic[T_co]):
-    def eval(self) -> T_co: ...
-
-
-def try_evaling(schedule: Schedule, expr: Expr, prim_expr: _EvalsTo[T]) -> T:
-    """
-    Try evaling the expression that will result in a primitive expression being fill.
-    if it fails, display the egraph and raise an error.
-    """
-    egraph = EGraph.current or EGraph()
-    with egraph.set_current():
-        try:
-            return prim_expr.eval()
-        except BaseException:  # noqa: S110
-            pass
-    # If this primitive doesn't exist in the egraph, we need to try to create it by
-    # registering the expression and running the schedule
-    egraph.register(expr)
-    egraph.run(Schedule.current or schedule)
-    try:
-        with egraph.set_current():
-            return prim_expr.eval()
-    except BaseException as e:
-        # egraph.display(n_inline_leaves=1, split_primitive_outputs=True)
-        e.add_note(f"Cannot evaluate {egraph.extract(expr)}")
-        raise

--- a/python/egglog/examples/bignum.py
+++ b/python/egglog/examples/bignum.py
@@ -12,14 +12,15 @@ x = BigInt(-1234)
 y = BigInt.from_string("2")
 z = BigRat(x, y)
 
-assert z.numer.to_string() == "-617"
+egraph = EGraph()
+
+assert egraph.extract(z.numer.to_string()).eval() == "-617"
 
 
 @function
 def bignums(x: BigInt, y: BigInt) -> BigRat: ...
 
 
-egraph = EGraph()
 egraph.register(set_(bignums(x, y)).to(z))
 
 c = var("c", BigRat)

--- a/python/egglog/examples/eqsat_basic.py
+++ b/python/egglog/examples/eqsat_basic.py
@@ -28,18 +28,17 @@ expr2 = Num(6) + Num(2) * Num.var("x")
 a, b, c = vars_("a b c", Num)
 i, j = vars_("i j", i64)
 
-check(
-    # Check that these expressions are equal
-    eq(expr1).to(expr2),
-    # After running these rules, up to ten times
+egraph = EGraph()
+egraph.register(expr1, expr2)
+
+egraph.run(
     ruleset(
         rewrite(a + b).to(b + a),
         rewrite(a * (b + c)).to((a * b) + (a * c)),
         rewrite(Num(i) + Num(j)).to(Num(i + j)),
         rewrite(Num(i) * Num(j)).to(Num(i * j)),
     )
-    * 10,
-    # On these two initial expressions
-    expr1,
-    expr2,
+    * 10
 )
+
+egraph.check(expr1 == expr2)

--- a/python/egglog/examples/multiset.py
+++ b/python/egglog/examples/multiset.py
@@ -29,33 +29,32 @@ egraph = EGraph()
 xs = MultiSet(Math(1), Math(2), Math(3))
 egraph.register(xs)
 
-with egraph.set_current():
-    assert xs == MultiSet(Math(1), Math(3), Math(2))
-    assert xs != MultiSet(Math(1), Math(1), Math(2), Math(3))
+egraph.check(xs == MultiSet(Math(1), Math(3), Math(2)))
+egraph.check_fail(xs == MultiSet(Math(1), Math(1), Math(2), Math(3)))
 
-    assert Counter(xs) == Counter({Math(1): 1, Math(2): 1, Math(3): 1})
+assert Counter(egraph.extract(xs).eval()) == Counter({Math(1): 1, Math(2): 1, Math(3): 1})
 
-    inserted = MultiSet(Math(1), Math(2), Math(3), Math(4))
-    egraph.register(inserted)
-    assert xs.insert(Math(4)) == inserted
 
-    assert xs.contains(Math(1))
-    assert xs.not_contains(Math(4))
-    assert Math(1) in xs
-    assert Math(4) not in xs
+inserted = MultiSet(Math(1), Math(2), Math(3), Math(4))
+egraph.register(inserted)
+egraph.check(xs.insert(Math(4)) == inserted)
+egraph.check(xs.contains(Math(1)))
+egraph.check(xs.not_contains(Math(4)))
+assert Math(1) in xs
+assert Math(4) not in xs
 
-    assert xs.remove(Math(1)) == MultiSet(Math(2), Math(3))
+egraph.check(xs.remove(Math(1)) == MultiSet(Math(2), Math(3)))
 
-    assert xs.length() == i64(3)
-    assert len(xs) == 3
+assert egraph.extract(xs.length()).eval() == 3
+assert len(xs) == 3
 
-    assert MultiSet(Math(1), Math(1)).length() == i64(2)
+egraph.check(MultiSet(Math(1), Math(1)).length() == i64(2))
 
-    assert MultiSet(Math(1)).pick() == Math(1)
+egraph.check(MultiSet(Math(1)).pick() == Math(1))
 
-    mapped = xs.map(square)
-    egraph.register(mapped)
-    egraph.run(math_ruleset)
-    assert mapped == MultiSet(Math(1), Math(4), Math(9))
+mapped = xs.map(square)
+egraph.register(mapped)
+egraph.run(math_ruleset)
+egraph.check(mapped == MultiSet(Math(1), Math(4), Math(9)))
 
-    assert xs + xs == MultiSet(Math(1), Math(2), Math(3), Math(1), Math(2), Math(3))
+egraph.check(xs + xs == MultiSet(Math(1), Math(2), Math(3), Math(1), Math(2), Math(3)))

--- a/python/tests/test_high_level.py
+++ b/python/tests/test_high_level.py
@@ -243,30 +243,30 @@ def test_default_args():
 
 class TestPyObject:
     def test_from_string(self):
-        assert PyObject.from_string("foo").eval() == "foo"
+        assert EGraph().extract(PyObject.from_string("foo")).eval() == "foo"
 
     def test_to_string(self):
-        assert PyObject("foo").to_string().eval() == "foo"
+        EGraph().check(PyObject("foo").to_string() == String("foo"))
 
     def test_dict_update(self):
         original_d = {"foo": "bar"}
-        res = PyObject(original_d).dict_update("foo", "baz").eval()
+        res = EGraph().extract(PyObject(original_d).dict_update("foo", "baz")).eval()
         assert res == {"foo": "baz"}
         assert original_d == {"foo": "bar"}
 
     def test_eval(self):
-        assert py_eval("x + y", {"x": 10, "y": 20}, {}).eval() == 30
+        assert EGraph().extract(py_eval("x + y", {"x": 10, "y": 20}, {})).eval() == 30
 
     def test_eval_local(self):
         x = "hi"
         res = py_eval("my_add(x, y)", PyObject(locals()).dict_update("y", "there"), globals())
-        assert res.eval() == "hithere"  # Updated to call eval() directly on res
+        assert EGraph().extract(res).eval() == "hithere"
 
     def test_exec(self):
-        assert py_exec("x = 10").eval() == {"x": 10}  # Updated to call eval() directly on res
+        assert EGraph().extract(py_exec("x = 10")).eval() == {"x": 10}
 
     def test_exec_globals(self):
-        assert py_exec("x = y + 1", {"y": 10}).eval() == {"x": 11}
+        assert EGraph().extract(py_exec("x = y + 1", {"y": 10})).eval() == {"x": 11}
 
 
 def my_add(a, b):
@@ -502,7 +502,7 @@ class TestEval:
         assert String("c") not in m
 
     def test_set(self):
-        assert Set[i64].empty().eval() == set()
+        assert EGraph().extract(Set[i64].empty()).eval() == set()
         s = Set(i64(1), i64(2))
         assert s.eval() == {i64(1), i64(2)}
 
@@ -532,11 +532,12 @@ class TestEval:
         assert PyObject(o).eval() is o
 
     def test_big_int(self):
-        assert int(BigInt(10)) == 10
+        assert int(EGraph().extract(BigInt(10))) == 10
 
     def test_big_rat(self):
-        assert float(BigRat(1, 2)) == 1 / 2
-        assert BigRat(1, 2).eval() == Fraction(1, 2)
+        br = EGraph().extract(BigRat(1, 2))
+        assert float(br) == 1 / 2
+        assert br.eval() == Fraction(1, 2)
 
     def test_multiset(self):
         assert list(MultiSet(i64(1), i64(1))) == [i64(1), i64(1)]
@@ -555,7 +556,7 @@ class TestEval:
 
 
 def test_eval_fn():
-    assert py_eval_fn(lambda x: (x,))(PyObject.from_int(1)).eval() == (1,)
+    assert EGraph().extract(py_eval_fn(lambda x: (x,))(PyObject.from_int(1))).eval() == (1,)
 
 
 def _global_make_tuple(x):
@@ -563,16 +564,14 @@ def _global_make_tuple(x):
 
 
 def test_eval_fn_globals():
-    assert py_eval_fn(lambda x: _global_make_tuple(x))(PyObject.from_int(1)).eval() == (1,)
+    assert EGraph().extract(py_eval_fn(lambda x: _global_make_tuple(x))(PyObject.from_int(1))).eval() == (1,)
 
 
 def test_eval_fn_locals():
-    EGraph()
-
     def _locals_make_tuple(x):
         return (x,)
 
-    assert py_eval_fn(lambda x: _locals_make_tuple(x))(PyObject.from_int(1)).eval() == (1,)
+    assert EGraph().extract(py_eval_fn(lambda x: _locals_make_tuple(x))(PyObject.from_int(1))).eval() == (1,)
 
 
 def test_lazy_types():
@@ -831,16 +830,13 @@ def test_map_like_conversion():
 
 class TestEqNE:
     def test_eq(self):
-        assert (i64(1) + 2) == 3
+        assert i64(3) == i64(3)
 
     def test_ne(self):
-        assert (i64(1) + 2) != 4
+        EGraph().check(i64(3) != i64(4))
 
     def test_eq_false(self):
-        assert not ((i64(1) + 2) == 4)  # noqa: SIM201
-
-    def test_ne_false(self):
-        assert not ((i64(1) + 2) != 3)  # noqa: SIM202
+        assert not (i64(3) == 4)  # noqa: SIM201
 
 
 EXAMPLE_FILES = list((pathlib.Path(__file__).parent / "../egglog/examples").glob("*.py"))

--- a/python/tests/test_high_level.py
+++ b/python/tests/test_high_level.py
@@ -839,6 +839,25 @@ class TestEqNE:
         assert not (i64(3) == 4)  # noqa: SIM201
 
 
+def test_no_upcast_eq():
+    """
+    Verifies that if two items can be upcast to something, calling == on them won't use
+    equality
+    """
+
+    class A(Expr):
+        def __init__(self) -> None: ...
+
+    class B(Expr):
+        def __init__(self) -> None: ...
+        def __eq__(self, other: B) -> B: ...  # type: ignore[override]
+
+    converter(A, B, lambda a: B())
+
+    assert isinstance(A() == A(), Fact)
+    assert not isinstance(B() == B(), Fact)
+
+
 EXAMPLE_FILES = list((pathlib.Path(__file__).parent / "../egglog/examples").glob("*.py"))
 
 

--- a/python/tests/test_program_gen.py
+++ b/python/tests/test_program_gen.py
@@ -59,9 +59,8 @@ def test_to_string(snapshot_py) -> None:
     egraph = EGraph()
     egraph.register(fn.compile())
     egraph.run((to_program_ruleset | program_gen_ruleset).saturate())
-    with egraph.set_current():
-        assert fn.expr.eval() == "my_fn"
-        assert fn.statements.eval() == snapshot_py
+    egraph.check(fn.expr == String("my_fn"))
+    assert egraph.extract(fn.statements).eval() == snapshot_py
 
 
 def test_to_string_function_three(snapshot_py) -> None:
@@ -72,9 +71,8 @@ def test_to_string_function_three(snapshot_py) -> None:
     egraph = EGraph()
     egraph.register(fn.compile())
     egraph.run((to_program_ruleset | program_gen_ruleset).saturate())
-    with egraph.set_current():
-        assert fn.expr.eval() == "my_fn"
-        assert fn.statements.eval() == snapshot_py
+    assert egraph.extract(fn.expr).eval() == "my_fn"
+    assert egraph.extract(fn.statements).eval() == snapshot_py
 
 
 def test_py_object():
@@ -86,7 +84,6 @@ def test_py_object():
     egraph = EGraph()
     egraph.register(evalled)
     egraph.run((to_program_ruleset | eval_program_rulseset | program_gen_ruleset).saturate())
-    with egraph.set_current():
-        res = cast("FunctionType", evalled.as_py_object.eval())
+    res = cast("FunctionType", egraph.extract(evalled.as_py_object).eval())
     assert res(1, 2) == 13
     assert inspect.getsource(res)


### PR DESCRIPTION
In https://github.com/egraphs-good/egglog-python/pull/265 (released as 9.0.0) the ability to automatically extract a builtin using a global egraph context was added. This PR removes that feature, requiring all builtins to be in a normalized form.

I realized that for https://github.com/egraphs-good/egglog-python/issues/241 we want facts to compare structural equality when converting to a boolean, instead of using the e-graph. Looking at that previous PR, it seems like a mistake to add this implicit context, making things more confusing and opaque with minimal UX improvements.