### PR TITLE
Fix bug resolving types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "egglog_python"
-version = "9.0.1"
+version = "10.0.0"
 dependencies = [
  "egglog",
  "egglog-experimental",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,8 @@ _This project uses semantic versioning_
 ## UNRELEASED
 
 - Fix bug on resolving types if not all imported to your module [#286](https://github.com/egraphs-good/egglog-python/pull/286)
+  - Also stops special casing including `Callable` as a global. So if you previously included this in a `TYPE_CHECKING` block so it wasn
+    available at runtime you will have to move this to a runtime import if used in a type alias.
 
 ## 10.0.0 (2025-03-28)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,8 @@ _This project uses semantic versioning_
 
 ## UNRELEASED
 
+- Fix bug on resolving types if not all imported to your module
+
 ## 10.0.0 (2025-03-28)
 
 - Change builtins to not evaluate values in egraph and changes facts to compare structural equality instead of using an egraph when converting to a boolean, removing magic context (`EGraph.current` and `Schedule.current`) that was added in release 9.0.0.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,7 @@ _This project uses semantic versioning_
 
 ## UNRELEASED
 
-- Fix bug on resolving types if not all imported to your module
+- Fix bug on resolving types if not all imported to your module [#286](https://github.com/egraphs-good/egglog-python/pull/286)
 
 ## 10.0.0 (2025-03-28)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,6 +198,10 @@ ignore = [
     "SLF001",
     # allow blind exception to add context
     "BLE001",
+    # Don't move type checking around so that can be accessed at runtime
+    "TCH001",
+    "TCH002",
+    "TCH003",
 ]
 select = ["ALL"]
 
@@ -216,6 +220,14 @@ preview = true
 [tool.ruff.lint.per-file-ignores]
 # Don't require annotations for tests
 "python/tests/**" = ["ANN001", "ANN201", "INP001"]
+
+# [tool.ruff.lint.flake8-type-checking]
+# runtime-evaluated-decorators = [
+#     "egglog.function",
+#     "egglog.method",
+#     "egglog.ruleset",
+# ]
+# runtime-evaluated-base-classes = ["egglog.Expr"]
 
 [tool.mypy]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,6 +221,7 @@ preview = true
 # Don't require annotations for tests
 "python/tests/**" = ["ANN001", "ANN201", "INP001"]
 
+# Disable these tests instead for now since ruff doesn't support including all method annotations of decorated class
 # [tool.ruff.lint.flake8-type-checking]
 # runtime-evaluated-decorators = [
 #     "egglog.function",

--- a/python/egglog/builtins.py
+++ b/python/egglog/builtins.py
@@ -5,6 +5,7 @@ Builtin sorts and function to egg.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from fractions import Fraction
 from functools import partial, reduce
 from types import FunctionType, MethodType
@@ -20,7 +21,7 @@ from .runtime import RuntimeClass, RuntimeExpr, RuntimeFunction
 from .thunk import Thunk
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator
+    from collections.abc import Iterator
 
 
 __all__ = [

--- a/python/egglog/egraph.py
+++ b/python/egglog/egraph.py
@@ -1817,7 +1817,7 @@ def _rewrite_or_rule_generator(gen: RewriteOrRuleGenerator, frame: FrameType) ->
     """
     Returns a thunk which will call the function with variables of the type and name of the arguments.
     """
-    # Need to manually pass in the frame locals from the generator, because otherwise classes defined within funciton
+    # Need to manually pass in the frame locals from the generator, because otherwise classes defined within function
     # will not be available in the annotations
     # combine locals and globals so that they are the same dict. Otherwise get_type_hints will go through the wrong
     # path and give an error for the test

--- a/python/egglog/egraph.py
+++ b/python/egglog/egraph.py
@@ -1817,12 +1817,13 @@ def _rewrite_or_rule_generator(gen: RewriteOrRuleGenerator, frame: FrameType) ->
     """
     Returns a thunk which will call the function with variables of the type and name of the arguments.
     """
-    # Get the local scope from where the function is defined, so that we can get any type hints that are in the scope
-    # but not in the globals
-    globals = gen.__globals__.copy()
-    if "Callable" not in globals:
-        globals["Callable"] = Callable
-    hints = get_type_hints(gen, globals, frame.f_locals)
+    # Need to manually pass in the frame locals from the generator, because otherwise classes defined within funciton
+    # will not be available in the annotations
+    # combine locals and globals so that they are the same dict. Otherwise get_type_hints will go through the wrong
+    # path and give an error for the test
+    # python/tests/test_no_import_star.py::test_no_import_star_rulesset
+    combined = {**gen.__globals__, **frame.f_locals}
+    hints = get_type_hints(gen, combined, combined)
     args = [_var(p.name, hints[p.name]) for p in signature(gen).parameters.values()]
     return list(gen(*args))  # type: ignore[misc]
 

--- a/python/egglog/examples/higher_order_functions.py
+++ b/python/egglog/examples/higher_order_functions.py
@@ -6,12 +6,9 @@ Higher Order Functions
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from collections.abc import Callable
 
 from egglog import *
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 class Math(Expr):

--- a/python/egglog/examples/lambda_.py
+++ b/python/egglog/examples/lambda_.py
@@ -7,12 +7,11 @@ Lambda Calculus
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar
+from collections.abc import Callable
+from typing import ClassVar
 
 from egglog import *
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
+from egglog import Expr
 
 
 class Val(Expr):

--- a/python/egglog/exp/array_api.py
+++ b/python/egglog/exp/array_api.py
@@ -60,6 +60,7 @@ import math
 import numbers
 import os
 import sys
+from collections.abc import Callable
 from copy import copy
 from types import EllipsisType
 from typing import TYPE_CHECKING, Any, ClassVar, TypeAlias, cast
@@ -72,8 +73,9 @@ from egglog.runtime import RuntimeExpr
 from .program_gen import *
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator
+    from collections.abc import Iterator
     from types import ModuleType
+
 
 # Pretend that exprs are numbers b/c sklearn does isinstance checks
 numbers.Integral.register(RuntimeExpr)

--- a/python/tests/test_no_import_star.py
+++ b/python/tests/test_no_import_star.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import egglog as el
 
 
@@ -10,3 +12,15 @@ def test_no_import_star():
         def __init__(self, value: el.i64Like) -> None: ...
 
     Num(1)  # gets an error "NameError: name 'i64' is not defined"
+
+
+def test_no_import_star_rulesset():
+    """
+    https://github.com/egraphs-good/egglog-python/issues/283
+    """
+
+    @el.ruleset
+    def _rules(_: el.i64Like):
+        return []
+
+    el.EGraph().run(_rules)

--- a/python/tests/test_pretty.py
+++ b/python/tests/test_pretty.py
@@ -1,6 +1,7 @@
 # mypy: disable-error-code="empty-body"
 from __future__ import annotations
 
+from collections.abc import Callable
 from copy import copy
 from functools import partial
 from typing import TYPE_CHECKING, ClassVar
@@ -10,8 +11,6 @@ import pytest
 from egglog import *
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from egglog.runtime import RuntimeExpr
 
 

--- a/python/tests/test_unstable_fn.py
+++ b/python/tests/test_unstable_fn.py
@@ -5,13 +5,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from functools import partial
-from typing import TYPE_CHECKING, ClassVar, TypeAlias
+from typing import ClassVar, TypeAlias
 
 from egglog import *
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 class Math(Expr):


### PR DESCRIPTION
Closes #283 by fixing a runtime type resolution bug.

This also stops special casing adding `Callable` as global for type resolution and instead forces you to import all builtins and other types at runtime.