### PR TITLE
Fix tests not running on different Python version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,15 +26,12 @@ jobs:
           - "3.10"
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
+          python-version: ${{ matrix.py }}
       - uses: dtolnay/rust-toolchain@1.79.0
       - uses: Swatinem/rust-cache@v2
-      - name: Setup python ${{ matrix.py }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.py }}
       - run: uv sync --extra test --locked
       - run: uv run pytest --benchmark-disable -vvv --durations=10
 
@@ -42,15 +39,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
-      - uses: dtolnay/rust-toolchain@1.79.0
-      - uses: Swatinem/rust-cache@v2
-      - uses: actions/setup-python@v5
-        with:
           # Run on oldest Python version to catch more errors
           python-version: "3.10"
+      - uses: dtolnay/rust-toolchain@1.79.0
+      - uses: Swatinem/rust-cache@v2
       - run: uv sync --extra test --locked
       - run: make mypy
       - run: make stubtest
@@ -59,14 +54,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
       - uses: dtolnay/rust-toolchain@1.79.0
       - uses: Swatinem/rust-cache@v2
-      - uses: actions/setup-python@v5
-        with:
-          python-version-file: ".python-version"
       - run: uv sync --extra test --locked
       - uses: CodSpeedHQ/action@v3
         with:
@@ -78,14 +70,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
       - uses: dtolnay/rust-toolchain@1.79.0
       - uses: Swatinem/rust-cache@v2
-      - uses: actions/setup-python@v5
-        with:
-          python-version-file: ".python-version"
       - name: Install graphviz
         run: |
           sudo apt-get update


### PR DESCRIPTION
Try to fix the CI tests by running properly on different Python versions. Found by https://github.com/egraphs-good/egglog-python/issues/295