### PR TITLE
Fix python 3.10 compat

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,8 +42,6 @@ jobs:
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
-          # Run on oldest Python version to catch more errors
-          python-version: "3.10"
       - uses: dtolnay/rust-toolchain@1.79.0
       - uses: Swatinem/rust-cache@v2
       - run: uv sync --extra test --locked

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,8 @@ _This project uses semantic versioning_
 
 ## UNRELEASED
 
-- fix using `f64Like` when not importing star (also properly includes removal of `Callable` special case from previous release).
+- Fix using `f64Like` when not importing star (also properly includes removal of `Callable` special case from previous release).
+- Fix Python 3.10 compatibility
 
 ## 10.0.1 (2025-04-06)
 

--- a/python/egglog/declarations.py
+++ b/python/egglog/declarations.py
@@ -308,7 +308,7 @@ class ClassTypeVarRef:
     module: str
 
     def to_just(self) -> JustTypeRef:
-        msg = "egglog does not support generic classes yet."
+        msg = f"{self}: egglog does not support generic classes yet."
         raise NotImplementedError(msg)
 
     def __str__(self) -> str:

--- a/python/egglog/declarations.py
+++ b/python/egglog/declarations.py
@@ -312,7 +312,7 @@ class ClassTypeVarRef:
         raise NotImplementedError(msg)
 
     def __str__(self) -> str:
-        return f"{self.module}.{self.name}"
+        return str(self.to_type_var())
 
     @classmethod
     def from_type_var(cls, typevar: TypeVar) -> ClassTypeVarRef:

--- a/python/egglog/declarations.py
+++ b/python/egglog/declarations.py
@@ -93,7 +93,7 @@ class DelayedDeclerations:
         # Catch attribute error, so that it isn't bubbled up as a missing attribute and fallbacks on `__getattr__`
         # instead raise explicitly
         except AttributeError as err:
-            msg = f"Cannot resolve declerations for {self}"
+            msg = f"Cannot resolve declarations for {self}"
             raise RuntimeError(msg) from err
 
 

--- a/python/egglog/egraph.py
+++ b/python/egglog/egraph.py
@@ -16,7 +16,6 @@ from typing import (
     ClassVar,
     Generic,
     Literal,
-    Never,
     TypeAlias,
     TypedDict,
     TypeVar,
@@ -26,7 +25,7 @@ from typing import (
 )
 
 import graphviz
-from typing_extensions import ParamSpec, Self, Unpack, assert_never
+from typing_extensions import Never, ParamSpec, Self, Unpack, assert_never
 
 from . import bindings
 from .conversion import *
@@ -36,6 +35,7 @@ from .ipython_magic import IN_IPYTHON
 from .pretty import pretty_decl
 from .runtime import *
 from .thunk import *
+from .version_compat import *
 
 if TYPE_CHECKING:
     from .builtins import String, Unit
@@ -169,8 +169,9 @@ def check_eq(x: BASE_EXPR, y: BASE_EXPR, schedule: Schedule | None = None, *, ad
     except bindings.EggSmolError as err:
         if display:
             egraph.display()
-        err.add_note(f"Failed:\n{eq(x).to(y)}\n\nExtracted:\n {eq(egraph.extract(x)).to(egraph.extract(y))})")
-        raise
+        raise add_note(
+            f"Failed:\n{eq(x).to(y)}\n\nExtracted:\n {eq(egraph.extract(x)).to(egraph.extract(y))})", err
+        ) from None
     return egraph
 
 
@@ -492,8 +493,7 @@ def _generate_class_decls(  # noqa: C901,PLR0912
                 reverse_args=reverse_args,
             )
         except Exception as e:
-            e.add_note(f"Error processing {cls_name}.{method_name}")
-            raise
+            raise add_note(f"Error processing {cls_name}.{method_name}", e) from None
 
         if not builtin and not isinstance(ref, InitRef) and not mutates:
             add_default_funcs.append(add_rewrite)
@@ -1040,8 +1040,7 @@ class EGraph:
                 bindings.ActionCommand(bindings.Extract(span(2), expr, bindings.Lit(span(2), bindings.Int(n))))
             )
         except BaseException as e:
-            e.add_note("Extracting: " + str(expr))
-            raise
+            raise add_note("Extracting: " + str(expr), e)  # noqa: B904
         extract_report = self._egraph.extract_report()
         if not extract_report:
             msg = "No extract report saved"

--- a/python/egglog/egraph.py
+++ b/python/egglog/egraph.py
@@ -627,7 +627,7 @@ def _fn_decl(
     )
     decls |= merged
 
-    # defer this in generator so it doesnt resolve for builtins eagerly
+    # defer this in generator so it doesn't resolve for builtins eagerly
     args = (TypedExprDecl(tp.to_just(), VarDecl(name, False)) for name, tp in zip(arg_names, arg_types, strict=True))
     res_ref: FunctionRef | MethodRef | ClassMethodRef | PropertyRef | InitRef | UnnamedFunctionRef
     res_thunk: Callable[[], object]

--- a/python/egglog/egraph.py
+++ b/python/egglog/egraph.py
@@ -671,7 +671,7 @@ def _fn_decl(
             )
         res_ref = ref
         decls.set_function_decl(ref, decl)
-        res_thunk = Thunk.fn(_create_default_value, decls, ref, fn, args, ruleset)
+        res_thunk = Thunk.fn(_create_default_value, decls, ref, fn, args, ruleset, context=f"creating {ref}")
     return res_ref, Thunk.fn(_add_default_rewrite_function, decls, res_ref, return_type, ruleset, res_thunk, subsume)
 
 

--- a/python/egglog/runtime.py
+++ b/python/egglog/runtime.py
@@ -22,6 +22,7 @@ from .declarations import *
 from .pretty import *
 from .thunk import Thunk
 from .type_constraint_solver import *
+from .version_compat import *
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -249,8 +250,7 @@ class RuntimeClass(DelayedDeclerations):
         try:
             cls_decl = self.__egg_decls__._classes[self.__egg_tp__.name]
         except Exception as e:
-            e.add_note(f"Error processing class {self.__egg_tp__.name}")
-            raise
+            raise add_note(f"Error processing class {self.__egg_tp__.name}", e) from None
 
         preserved_methods = cls_decl.preserved_methods
         if name in preserved_methods:
@@ -318,8 +318,7 @@ class RuntimeFunction(DelayedDeclerations):
         try:
             signature = self.__egg_decls__.get_callable_decl(self.__egg_ref__).signature
         except Exception as e:
-            e.add_note(f"Failed to find callable {self}")
-            raise
+            raise add_note(f"Failed to find callable {self}", e)  # noqa: B904
         decls = self.__egg_decls__.copy()
         # Special case function application bc we dont support variadic generics yet generally
         if signature == "fn-app":

--- a/python/egglog/runtime.py
+++ b/python/egglog/runtime.py
@@ -281,6 +281,9 @@ class RuntimeClass(DelayedDeclerations):
     def __str__(self) -> str:
         return str(self.__egg_tp__)
 
+    def __repr__(self) -> str:
+        return str(self)
+
     # Make hashable so can go in Union
     def __hash__(self) -> int:
         return hash((id(self.__egg_decls_thunk__), self.__egg_tp__))

--- a/python/egglog/type_constraint_solver.py
+++ b/python/egglog/type_constraint_solver.py
@@ -107,7 +107,7 @@ class TypeConstraintSolver:
                 try:
                     return self._cls_typevar_index_to_type[cls_name][tp]
                 except KeyError as e:
-                    raise TypeConstraintError(f"Not enough bound typevars for {tp} in class {cls_name}") from e
+                    raise TypeConstraintError(f"Not enough bound typevars for {tp!r} in class {cls_name}") from e
             case TypeRefWithVars(name, args):
                 return JustTypeRef(name, tuple(self.substitute_typevars(arg, cls_name) for arg in args))
         assert_never(tp)

--- a/python/egglog/version_compat.py
+++ b/python/egglog/version_compat.py
@@ -1,0 +1,87 @@
+import collections
+import sys
+import types
+import typing
+
+BEFORE_3_11 = sys.version_info < (3, 11)
+
+__all__ = ["add_note"]
+
+
+def add_note(message: str, exc: BaseException) -> BaseException:
+    """
+    Backwards compatible add_note for Python <= 3.10
+    """
+    if BEFORE_3_11:
+        return exc
+    exc.add_note(message)
+    return exc
+
+
+# For Python version 3.10 need to monkeypatch this function so that RuntimeClass type parameters
+# will be collected as typevars
+if BEFORE_3_11:
+
+    @typing.no_type_check
+    def _collect_type_vars_monkeypatch(types_, typevar_types=None):
+        """
+        Collect all type variable contained
+        in types in order of first appearance (lexicographic order). For example::
+
+            _collect_type_vars((T, List[S, T])) == (T, S)
+        """
+        from .runtime import RuntimeClass
+
+        if typevar_types is None:
+            typevar_types = typing.TypeVar
+        tvars = []
+        for t in types_:
+            if isinstance(t, typevar_types) and t not in tvars:
+                tvars.append(t)
+            # **MONKEYPATCH CHANGE HERE TO ADD RuntimeClass**
+            if isinstance(t, (typing._GenericAlias, typing.GenericAlias, types.UnionType, RuntimeClass)):  # type: ignore[name-defined]
+                tvars.extend([t for t in t.__parameters__ if t not in tvars])
+        return tuple(tvars)
+
+    typing._collect_type_vars = _collect_type_vars_monkeypatch  # type: ignore[attr-defined]
+
+    @typing.no_type_check
+    @typing._tp_cache
+    def __getitem__monkeypatch(self, params):  # noqa: C901, PLR0912
+        from .runtime import RuntimeClass
+
+        if self.__origin__ in (typing.Generic, typing.Protocol):
+            # Can't subscript Generic[...] or Protocol[...].
+            raise TypeError(f"Cannot subscript already-subscripted {self}")
+        if not isinstance(params, tuple):
+            params = (params,)
+        params = tuple(typing._type_convert(p) for p in params)
+        if self._paramspec_tvars and any(isinstance(t, typing.ParamSpec) for t in self.__parameters__):
+            params = typing._prepare_paramspec_params(self, params)
+        else:
+            typing._check_generic(self, params, len(self.__parameters__))
+
+        subst = dict(zip(self.__parameters__, params, strict=False))
+        new_args = []
+        for arg in self.__args__:
+            if isinstance(arg, self._typevar_types):
+                if isinstance(arg, typing.ParamSpec):
+                    arg = subst[arg]  # noqa: PLW2901
+                    if not typing._is_param_expr(arg):
+                        raise TypeError(f"Expected a list of types, an ellipsis, ParamSpec, or Concatenate. Got {arg}")
+                else:
+                    arg = subst[arg]  # noqa: PLW2901
+            # **MONKEYPATCH CHANGE HERE TO ADD RuntimeClass**
+            elif isinstance(arg, (typing._GenericAlias, typing.GenericAlias, types.UnionType, RuntimeClass)):
+                subparams = arg.__parameters__
+                if subparams:
+                    subargs = tuple(subst[x] for x in subparams)
+                    arg = arg[subargs]  # noqa: PLW2901
+            # Required to flatten out the args for CallableGenericAlias
+            if self.__origin__ == collections.abc.Callable and isinstance(arg, tuple):
+                new_args.extend(arg)
+            else:
+                new_args.append(arg)
+        return self.copy_with(tuple(new_args))
+
+    typing._GenericAlias.__getitem__ = __getitem__monkeypatch  # type: ignore[attr-defined]


### PR DESCRIPTION
Fixes https://github.com/egraphs-good/egglog-python/issues/295

- Only use `add_note` on exceptions where it's supported
- monkeypatch generic typing on 3.10 to support typevars