### PR TITLE
Fix CodSpeed symbol resolution

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,13 +56,17 @@ jobs:
         runner: [ codspeed-macro, ubuntu-latest ]
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: "pyproject.toml"
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
       - uses: dtolnay/rust-toolchain@1.79.0
       - uses: Swatinem/rust-cache@v2
       - run: uv sync --extra test --locked
-      - uses: CodSpeedHQ/action@v3
+      - uses: CodSpeedHQ/action@v3.6.1
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           # allow updating snapshots due to indeterministic benchmarks


### PR DESCRIPTION
https://discord.com/channels/1065233827569598464/1391710232542973952/1391820740814438593

> Hello!
> 
> Indeed there is a problem with symbol resolution during your benchmark execution.
> Can you try by making two little tweaks ?
> 1. Use the `3.6.1` codspeed action version that we have released today (which is not default with v3 because of a slight edge case that should not impact you)
> 2.Could you also try to setup python by using
> ```
>       - name: Set up Python
>         uses: actions/setup-python@v5
>         with:
>           python-version-file: "pyproject.toml"
> ```
> In your workflow ? As indicated by https://codspeed.io/docs/benchmarks/python#usage-with-uv
> 
> This helps by making sure we are able to resolve symbols used by the python build in order to build the profiling information.
> 
> Let me know if this does not solve the issue so we can continue looking into it!