### PR TITLE
Remove walltime benchmarking for now

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         # Run on codspeed for walltime and ubuntu for instrumenentation
-        runner: [ codspeed-macro, ubuntu-latest ]
+        runner: [ ubuntu-latest ] # codspeed-macro,  disable for now till we set up custom runner for more minutes
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python


### PR DESCRIPTION
Ran out of free minutes and need to wait to set up custom github action runner to re-enable.