### PR TITLE
Bump Egglog version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,56 +27,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "anstream"
-version = "0.6.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
-dependencies = [
- "anstyle",
- "once_cell",
- "windows-sys",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,74 +75,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
-name = "cc"
-version = "1.2.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
-dependencies = [
- "shlex",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "clap"
-version = "4.5.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.5.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.5.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "concurrency"
@@ -396,19 +282,15 @@ version = "1.0.0"
 source = "git+https://github.com/egraphs-good//egglog.git?branch=main#0be495630546acffbd545ba60feb9302281ce95c"
 dependencies = [
  "add_primitive",
- "chrono",
- "clap",
  "core-relations 1.0.0 (git+https://github.com/egraphs-good//egglog.git?branch=main)",
  "dyn-clone",
  "egglog-bridge 1.0.0 (git+https://github.com/egraphs-good//egglog.git?branch=main)",
  "egraph-serialize",
- "env_logger",
  "hashbrown 0.15.2",
  "im-rc",
  "indexmap",
  "lazy_static",
  "log",
- "mimalloc",
  "num",
  "numeric-id 1.0.0 (git+https://github.com/egraphs-good//egglog.git?branch=main)",
  "ordered-float",
@@ -465,7 +347,7 @@ dependencies = [
 [[package]]
 name = "egglog-experimental"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-experimental?branch=python#4bb0142c4276622a4492b99f4113ff68c8c5023c"
+source = "git+https://github.com/egraphs-good/egglog-experimental?branch=cli#6d07a34ac76deec751f86f70d9b9358cd3e236ca"
 dependencies = [
  "egglog",
  "lazy_static",
@@ -511,29 +393,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "env_filter"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
 
 [[package]]
 name = "equivalent"
@@ -701,40 +560,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
-name = "jiff"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
 
 [[package]]
 name = "js-sys"
@@ -767,16 +596,6 @@ name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
-
-[[package]]
-name = "libmimalloc-sys"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
-dependencies = [
- "cc",
- "libc",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -813,15 +632,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "mimalloc"
-version = "0.1.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
-dependencies = [
- "libmimalloc-sys",
 ]
 
 [[package]]
@@ -1007,15 +817,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
-name = "portable-atomic-util"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
-dependencies = [
- "portable-atomic",
-]
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,18 +994,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1303,12 +1092,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
 name = "sized-chunks"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1323,12 +1106,6 @@ name = "smallvec"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
-
-[[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -1454,12 +1231,6 @@ dependencies = [
  "crossbeam",
  "numeric-id 1.0.0 (git+https://github.com/egraphs-good/egglog.git?branch=main)",
 ]
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,8 +4,8 @@ version = 4
 
 [[package]]
 name = "add_primitive"
-version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=5542549#55425498b92bab18fcf3ea35224e42e2ad0afff6"
+version = "1.0.0"
+source = "git+https://github.com/egraphs-good//egglog.git?branch=main#0be495630546acffbd545ba60feb9302281ce95c"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -125,6 +125,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
+name = "cc"
+version = "1.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,8 +196,17 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "concurrency"
-version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=cd51d04#cd51d048f9ef8e0bd9eac2966c35e054ac5c8368"
+version = "1.0.0"
+source = "git+https://github.com/egraphs-good//egglog.git?branch=main#0be495630546acffbd545ba60feb9302281ce95c"
+dependencies = [
+ "arc-swap",
+ "rayon",
+]
+
+[[package]]
+name = "concurrency"
+version = "1.0.0"
+source = "git+https://github.com/egraphs-good/egglog.git?branch=main#0be495630546acffbd545ba60feb9302281ce95c"
 dependencies = [
  "arc-swap",
  "rayon",
@@ -196,12 +214,12 @@ dependencies = [
 
 [[package]]
 name = "core-relations"
-version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=cd51d04#cd51d048f9ef8e0bd9eac2966c35e054ac5c8368"
+version = "1.0.0"
+source = "git+https://github.com/egraphs-good//egglog.git?branch=main#0be495630546acffbd545ba60feb9302281ce95c"
 dependencies = [
  "anyhow",
  "bumpalo",
- "concurrency",
+ "concurrency 1.0.0 (git+https://github.com/egraphs-good//egglog.git?branch=main)",
  "crossbeam-queue",
  "dashmap",
  "dyn-clone",
@@ -211,7 +229,7 @@ dependencies = [
  "lazy_static",
  "log",
  "num",
- "numeric-id",
+ "numeric-id 1.0.0 (git+https://github.com/egraphs-good//egglog.git?branch=main)",
  "once_cell",
  "petgraph",
  "rand",
@@ -219,7 +237,36 @@ dependencies = [
  "rustc-hash",
  "smallvec",
  "thiserror 2.0.12",
- "union-find",
+ "union-find 1.0.0 (git+https://github.com/egraphs-good//egglog.git?branch=main)",
+ "web-time",
+]
+
+[[package]]
+name = "core-relations"
+version = "1.0.0"
+source = "git+https://github.com/egraphs-good/egglog.git?branch=main#0be495630546acffbd545ba60feb9302281ce95c"
+dependencies = [
+ "anyhow",
+ "bumpalo",
+ "concurrency 1.0.0 (git+https://github.com/egraphs-good/egglog.git?branch=main)",
+ "crossbeam-queue",
+ "dashmap",
+ "dyn-clone",
+ "fixedbitset 0.5.7",
+ "hashbrown 0.15.2",
+ "indexmap",
+ "lazy_static",
+ "log",
+ "num",
+ "numeric-id 1.0.0 (git+https://github.com/egraphs-good/egglog.git?branch=main)",
+ "once_cell",
+ "petgraph",
+ "rand",
+ "rayon",
+ "rustc-hash",
+ "smallvec",
+ "thiserror 2.0.12",
+ "union-find 1.0.0 (git+https://github.com/egraphs-good/egglog.git?branch=main)",
  "web-time",
 ]
 
@@ -345,15 +392,15 @@ checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "egglog"
-version = "0.5.0"
-source = "git+https://github.com/egraphs-good/egglog.git?rev=5542549#55425498b92bab18fcf3ea35224e42e2ad0afff6"
+version = "1.0.0"
+source = "git+https://github.com/egraphs-good//egglog.git?branch=main#0be495630546acffbd545ba60feb9302281ce95c"
 dependencies = [
  "add_primitive",
  "chrono",
  "clap",
- "core-relations",
+ "core-relations 1.0.0 (git+https://github.com/egraphs-good//egglog.git?branch=main)",
  "dyn-clone",
- "egglog-bridge",
+ "egglog-bridge 1.0.0 (git+https://github.com/egraphs-good//egglog.git?branch=main)",
  "egraph-serialize",
  "env_logger",
  "hashbrown 0.15.2",
@@ -361,9 +408,11 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "log",
+ "mimalloc",
  "num",
- "numeric-id",
+ "numeric-id 1.0.0 (git+https://github.com/egraphs-good//egglog.git?branch=main)",
  "ordered-float",
+ "rayon",
  "rustc-hash",
  "thiserror 2.0.12",
  "web-time",
@@ -371,30 +420,52 @@ dependencies = [
 
 [[package]]
 name = "egglog-bridge"
-version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=cd51d04#cd51d048f9ef8e0bd9eac2966c35e054ac5c8368"
+version = "1.0.0"
+source = "git+https://github.com/egraphs-good//egglog.git?branch=main#0be495630546acffbd545ba60feb9302281ce95c"
 dependencies = [
  "anyhow",
- "core-relations",
+ "core-relations 1.0.0 (git+https://github.com/egraphs-good//egglog.git?branch=main)",
  "dyn-clone",
  "hashbrown 0.15.2",
  "indexmap",
  "log",
  "num-rational",
- "numeric-id",
+ "numeric-id 1.0.0 (git+https://github.com/egraphs-good//egglog.git?branch=main)",
  "once_cell",
  "petgraph",
  "rayon",
  "smallvec",
  "thiserror 1.0.69",
- "union-find",
+ "union-find 1.0.0 (git+https://github.com/egraphs-good//egglog.git?branch=main)",
+ "web-time",
+]
+
+[[package]]
+name = "egglog-bridge"
+version = "1.0.0"
+source = "git+https://github.com/egraphs-good/egglog.git?branch=main#0be495630546acffbd545ba60feb9302281ce95c"
+dependencies = [
+ "anyhow",
+ "core-relations 1.0.0 (git+https://github.com/egraphs-good/egglog.git?branch=main)",
+ "dyn-clone",
+ "hashbrown 0.15.2",
+ "indexmap",
+ "log",
+ "num-rational",
+ "numeric-id 1.0.0 (git+https://github.com/egraphs-good/egglog.git?branch=main)",
+ "once_cell",
+ "petgraph",
+ "rayon",
+ "smallvec",
+ "thiserror 1.0.69",
+ "union-find 1.0.0 (git+https://github.com/egraphs-good/egglog.git?branch=main)",
  "web-time",
 ]
 
 [[package]]
 name = "egglog-experimental"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-experimental?rev=255b67a#255b67afaaac6436fee57cc2b9f4650e00c3408c"
+source = "git+https://github.com/egraphs-good/egglog-experimental?branch=python#4bb0142c4276622a4492b99f4113ff68c8c5023c"
 dependencies = [
  "egglog",
  "lazy_static",
@@ -406,9 +477,9 @@ dependencies = [
 name = "egglog_python"
 version = "11.0.0"
 dependencies = [
- "core-relations",
+ "core-relations 1.0.0 (git+https://github.com/egraphs-good/egglog.git?branch=main)",
  "egglog",
- "egglog-bridge",
+ "egglog-bridge 1.0.0 (git+https://github.com/egraphs-good/egglog.git?branch=main)",
  "egglog-experimental",
  "egraph-serialize",
  "lalrpop-util",
@@ -698,6 +769,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,6 +813,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -809,8 +899,17 @@ dependencies = [
 
 [[package]]
 name = "numeric-id"
-version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=cd51d04#cd51d048f9ef8e0bd9eac2966c35e054ac5c8368"
+version = "1.0.0"
+source = "git+https://github.com/egraphs-good//egglog.git?branch=main#0be495630546acffbd545ba60feb9302281ce95c"
+dependencies = [
+ "lazy_static",
+ "rayon",
+]
+
+[[package]]
+name = "numeric-id"
+version = "1.0.0"
+source = "git+https://github.com/egraphs-good/egglog.git?branch=main#0be495630546acffbd545ba60feb9302281ce95c"
 dependencies = [
  "lazy_static",
  "rayon",
@@ -1204,6 +1303,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "sized-chunks"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1332,12 +1437,22 @@ checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "union-find"
-version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=cd51d04#cd51d048f9ef8e0bd9eac2966c35e054ac5c8368"
+version = "1.0.0"
+source = "git+https://github.com/egraphs-good//egglog.git?branch=main#0be495630546acffbd545ba60feb9302281ce95c"
 dependencies = [
- "concurrency",
+ "concurrency 1.0.0 (git+https://github.com/egraphs-good//egglog.git?branch=main)",
  "crossbeam",
- "numeric-id",
+ "numeric-id 1.0.0 (git+https://github.com/egraphs-good//egglog.git?branch=main)",
+]
+
+[[package]]
+name = "union-find"
+version = "1.0.0"
+source = "git+https://github.com/egraphs-good/egglog.git?branch=main#0be495630546acffbd545ba60feb9302281ce95c"
+dependencies = [
+ "concurrency 1.0.0 (git+https://github.com/egraphs-good/egglog.git?branch=main)",
+ "crossbeam",
+ "numeric-id 1.0.0 (git+https://github.com/egraphs-good/egglog.git?branch=main)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "egglog_python"
-version = "11.0.0"
+version = "11.1.0"
 dependencies = [
  "core-relations 1.0.0 (git+https://github.com/egraphs-good/egglog.git?branch=main)",
  "egglog",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = { version = "0.24.2", features = ["extension-module"] }
 
-egglog = { git = "https://github.com/egraphs-good/egglog.git", branch = "main" }
+egglog = { git = "https://github.com/egraphs-good/egglog.git", branch = "main", default-features = false }
 # egglog = { path = "../egg-smol" }
 egglog-bridge = { git = "https://github.com/egraphs-good/egglog.git", branch = "main" }
 core-relations = { git = "https://github.com/egraphs-good/egglog.git", branch = "main" }
-egglog-experimental = { git = "https://github.com/egraphs-good/egglog-experimental", branch = "python" }
+egglog-experimental = { git = "https://github.com/egraphs-good/egglog-experimental", branch = "cli", default-features = false }
 egraph-serialize = { version = "0.2.0", features = ["serde", "graphviz"] }
 serde_json = "1.0.140"
 pyo3-log = "0.12.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = { version = "0.24.2", features = ["extension-module"] }
 
-egglog = { git = "https://github.com/egraphs-good/egglog.git", rev = "5542549" }
+egglog = { git = "https://github.com/egraphs-good/egglog.git", branch = "main" }
 # egglog = { path = "../egg-smol" }
-egglog-bridge = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "cd51d04" }
-core-relations = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "cd51d04" }
-egglog-experimental = { git = "https://github.com/egraphs-good/egglog-experimental", rev = "255b67a" }
+egglog-bridge = { git = "https://github.com/egraphs-good/egglog.git", branch = "main" }
+core-relations = { git = "https://github.com/egraphs-good/egglog.git", branch = "main" }
+egglog-experimental = { git = "https://github.com/egraphs-good/egglog-experimental", branch = "python" }
 egraph-serialize = { version = "0.2.0", features = ["serde", "graphviz"] }
 serde_json = "1.0.140"
 pyo3-log = "0.12.4"
@@ -28,7 +28,7 @@ rayon = "1.10.0"
 
 # Use patched version of egglog in experimental
 [patch.'https://github.com/egraphs-good/egglog']
-# egglog = { git = "https://github.com/egraphs-good//egglog.git", rev = "d2fa5b733de0796fb187dc5a27e570d5644aa75a" }
+egglog = { git = "https://github.com/egraphs-good//egglog.git", branch = "main" }
 # egglog = { path = "../egg-smol" }
 # egglog = { git = "https://github.com/egraphs-good//egglog.git", rev = "5542549" }
 

--- a/python/egglog/bindings.pyi
+++ b/python/egglog/bindings.pyi
@@ -45,7 +45,7 @@ __all__ = [
     "Pop",
     "PrintAllFunctionsSize",
     "PrintFunction",
-    "PrintFunctionOuput",
+    "PrintFunctionOutput",
     "PrintFunctionSize",
     "PrintOverallStatistics",
     "PrintSize",
@@ -431,7 +431,7 @@ class RunScheduleOutput:
     def __init__(self, report: RunReport) -> None: ...
 
 @final
-class PrintFunctionOuput:
+class PrintFunctionOutput:
     function: Function
     termdag: TermDag
     terms: list[tuple[_Term, _Term]]
@@ -452,7 +452,7 @@ _CommandOutput: TypeAlias = (
     | ExtractBest
     | OverallStatistics
     | RunScheduleOutput
-    | PrintFunctionOuput
+    | PrintFunctionOutput
     | UserDefinedOutput
 )
 

--- a/python/egglog/bindings.pyi
+++ b/python/egglog/bindings.pyi
@@ -7,15 +7,16 @@ from typing_extensions import final
 __all__ = [
     "ActionCommand",
     "AddRuleset",
-    "Best",
     "BiRewriteCommand",
     "Bool",
+    "CSVPrintFunctionMode",
     "Call",
     "Change",
     "Check",
     "Constructor",
     "Datatype",
     "Datatypes",
+    "DefaultPrintFunctionMode",
     "Delete",
     "EGraph",
     "EggSmolError",
@@ -23,10 +24,13 @@ __all__ = [
     "Eq",
     "Expr_",
     "Extract",
+    "ExtractBest",
+    "ExtractVariants",
     "Fact",
     "Fail",
     "Float",
     "Function",
+    "FunctionCommand",
     "IdentSort",
     "Include",
     "Input",
@@ -35,10 +39,14 @@ __all__ = [
     "Lit",
     "NewSort",
     "Output",
+    "OverallStatistics",
     "Panic",
     "PanicSpan",
     "Pop",
+    "PrintAllFunctionsSize",
     "PrintFunction",
+    "PrintFunctionOuput",
+    "PrintFunctionSize",
     "PrintOverallStatistics",
     "PrintSize",
     "Push",
@@ -53,13 +61,13 @@ __all__ = [
     "RunConfig",
     "RunReport",
     "RunSchedule",
+    "RunScheduleOutput",
     "RustSpan",
     "Saturate",
     "Schema",
     "Sequence",
     "SerializedEGraph",
     "Set",
-    "SetOption",
     "Sort",
     "SrcFile",
     "String",
@@ -73,13 +81,18 @@ __all__ = [
     "Unit",
     "UnstableCombinedRuleset",
     "UserDefined",
+    "UserDefinedCommandOutput",
+    "UserDefinedOutput",
     "Var",
     "Variant",
-    "Variants",
 ]
 
 @final
 class SerializedEGraph:
+    @property
+    def truncated_functions(self) -> list[str]: ...
+    @property
+    def discarded_functions(self) -> list[str]: ...
     def inline_leaves(self) -> None: ...
     def saturate_inline_leaves(self) -> None: ...
     def to_dot(self) -> str: ...
@@ -106,9 +119,7 @@ class EGraph:
     ) -> None: ...
     def parse_program(self, __input: str, /, filename: str | None = None) -> list[_Command]: ...
     def commands(self) -> str | None: ...
-    def run_program(self, *commands: _Command) -> list[str]: ...
-    def extract_report(self) -> _ExtractReport | None: ...
-    def run_report(self) -> RunReport | None: ...
+    def run_program(self, *commands: _Command) -> list[_CommandOutput]: ...
     def serialize(
         self,
         root_eclasses: list[_Expr],
@@ -357,6 +368,13 @@ class IdentSort:
     def __init__(self, ident: str, sort: str) -> None: ...
 
 @final
+class UserDefinedCommandOutput: ...
+
+@final
+class Function:
+    name: str
+
+@final
 class RunReport:
     updated: bool
     search_and_apply_time_per_rule: dict[str, timedelta]
@@ -375,20 +393,80 @@ class RunReport:
         rebuild_time_per_ruleset: dict[str, timedelta],
     ) -> None: ...
 
+##
+# Command Outputs
+##
+
 @final
-class Variants:
+class PrintFunctionSize:
+    size: int
+    def __init__(self, size: int) -> None: ...
+
+@final
+class PrintAllFunctionsSize:
+    sizes: list[tuple[str, int]]
+    def __init__(self, sizes: list[tuple[str, int]]) -> None: ...
+
+@final
+class ExtractVariants:
     termdag: TermDag
     terms: list[_Term]
     def __init__(self, termdag: TermDag, terms: list[_Term]) -> None: ...
 
 @final
-class Best:
+class ExtractBest:
     termdag: TermDag
     cost: int
     term: _Term
     def __init__(self, termdag: TermDag, cost: int, term: _Term) -> None: ...
 
-_ExtractReport: TypeAlias = Variants | Best
+@final
+class OverallStatistics:
+    report: RunReport
+    def __init__(self, report: RunReport) -> None: ...
+
+@final
+class RunScheduleOutput:
+    report: RunReport
+    def __init__(self, report: RunReport) -> None: ...
+
+@final
+class PrintFunctionOuput:
+    function: Function
+    termdag: TermDag
+    terms: list[tuple[_Term, _Term]]
+    mode: _PrintFunctionMode
+    def __init__(
+        self, function: Function, termdag: TermDag, terms: list[tuple[_Term, _Term]], mode: _PrintFunctionMode
+    ) -> None: ...
+
+@final
+class UserDefinedOutput:
+    output: UserDefinedCommandOutput
+    def __init__(self, output: UserDefinedCommandOutput) -> None: ...
+
+_CommandOutput: TypeAlias = (
+    PrintFunctionSize
+    | PrintAllFunctionsSize
+    | ExtractVariants
+    | ExtractBest
+    | OverallStatistics
+    | RunScheduleOutput
+    | PrintFunctionOuput
+    | UserDefinedOutput
+)
+
+##
+# Print Function Modes
+##
+
+@final
+class DefaultPrintFunctionMode: ...
+
+@final
+class CSVPrintFunctionMode: ...
+
+_PrintFunctionMode: TypeAlias = DefaultPrintFunctionMode | CSVPrintFunctionMode
 
 ##
 # Schedules
@@ -443,12 +521,6 @@ _Subdatatypes: TypeAlias = SubVariants | NewSort
 ##
 
 @final
-class SetOption:
-    name: str
-    value: _Expr
-    def __init__(self, name: str, value: _Expr) -> None: ...
-
-@final
 class Datatype:
     span: _Span
     name: str
@@ -469,7 +541,7 @@ class Sort:
     def __init__(self, span: _Span, name: str, presort_and_args: tuple[str, list[_Expr]] | None = None) -> None: ...
 
 @final
-class Function:
+class FunctionCommand:
     span: _Span
     name: str
     schema: Schema
@@ -531,8 +603,12 @@ class Check:
 class PrintFunction:
     span: _Span
     name: str
-    length: int
-    def __init__(self, span: _Span, name: str, length: int) -> None: ...
+    length: int | None
+    filename: str | None
+    mode: _PrintFunctionMode
+    def __init__(
+        self, span: _Span, name: str, length: int | None, filename: str | None, mode: _PrintFunctionMode
+    ) -> None: ...
 
 @final
 class PrintSize:
@@ -613,11 +689,10 @@ class UnstableCombinedRuleset:
     def __init__(self, span: _Span, name: str, rulesets: list[str]) -> None: ...
 
 _Command: TypeAlias = (
-    SetOption
-    | Datatype
+    Datatype
     | Datatypes
     | Sort
-    | Function
+    | FunctionCommand
     | AddRuleset
     | RuleCommand
     | RewriteCommand

--- a/python/egglog/egraph_state.py
+++ b/python/egglog/egraph_state.py
@@ -263,7 +263,7 @@ class EGraphState:
                         self.egraph.run_program(bindings.Relation(span(), egg_name, schema.input))
                     else:
                         self.egraph.run_program(
-                            bindings.Function(
+                            bindings.FunctionCommand(
                                 span(),
                                 egg_name,
                                 self._signature_to_egg_schema(signature),

--- a/python/egglog/exp/array_api.py
+++ b/python/egglog/exp/array_api.py
@@ -729,7 +729,7 @@ int64 = DType.int64
 _DTYPES = [float64, float32, int32, int64, DType.object]
 
 converter(type, DType, lambda x: convert(np.dtype(x), DType))
-converter(type(np.dtype), DType, lambda x: getattr(DType, x.name))
+converter(type(np.dtype), DType, lambda x: getattr(DType, x.name))  # type:ignore[call-overload]
 
 
 @array_api_ruleset.register

--- a/python/egglog/exp/array_api.py
+++ b/python/egglog/exp/array_api.py
@@ -729,7 +729,7 @@ int64 = DType.int64
 _DTYPES = [float64, float32, int32, int64, DType.object]
 
 converter(type, DType, lambda x: convert(np.dtype(x), DType))
-converter(type(np.dtype), DType, lambda x: getattr(DType, x.name))  # type: ignore[call-overload]
+converter(type(np.dtype), DType, lambda x: getattr(DType, x.name))
 
 
 @array_api_ruleset.register

--- a/python/tests/test_bindings.py
+++ b/python/tests/test_bindings.py
@@ -95,7 +95,7 @@ class TestEGraph:
 
     def test_run_rules(self):
         egraph = EGraph()
-        egraph.run_program(
+        res = egraph.run_program(
             Datatype(DUMMY_SPAN, "Math", [Variant(DUMMY_SPAN, "Add", ["Math", "Math"])]),
             RewriteCommand(
                 "",
@@ -109,20 +109,21 @@ class TestEGraph:
             RunSchedule(Repeat(DUMMY_SPAN, 10, Run(DUMMY_SPAN, RunConfig("")))),
         )
 
-        run_report = egraph.run_report()
-        assert isinstance(run_report, RunReport)
+        assert len(res) == 1
+        assert isinstance(res[0], RunScheduleOutput)
 
     def test_extract(self):
         # Example from extraction-cost
         egraph = EGraph()
-        egraph.run_program(
+        res = egraph.run_program(
             Datatype(DUMMY_SPAN, "Expr", [Variant(DUMMY_SPAN, "Num", ["i64"], cost=5)]),
             ActionCommand(Let(DUMMY_SPAN, "x", Call(DUMMY_SPAN, "Num", [Lit(DUMMY_SPAN, Int(1))]))),
             Extract(DUMMY_SPAN, Var(DUMMY_SPAN, "x"), Lit(DUMMY_SPAN, Int(0))),
         )
 
-        extract_report = egraph.extract_report()
-        assert isinstance(extract_report, Best)
+        assert len(res) == 1
+        extract_report = res[0]
+        assert isinstance(extract_report, ExtractBest)
         assert extract_report.cost == 6
         assert extract_report.termdag.term_to_expr(extract_report.term, DUMMY_SPAN) == Call(
             DUMMY_SPAN, "Num", [Lit(DUMMY_SPAN, Int(1))]

--- a/python/tests/test_py_object_sort.py
+++ b/python/tests/test_py_object_sort.py
@@ -61,7 +61,7 @@ class TestDictUpdate:
         new_value_expr = sort.store(2)
         a_expr = sort.store("a")
         b_expr = sort.store("b")
-        egraph.run_program(
+        res = egraph.run_program(
             ActionCommand(
                 Let(
                     DUMMY_SPAN,
@@ -71,8 +71,9 @@ class TestDictUpdate:
             ),
             Extract(DUMMY_SPAN, Var(DUMMY_SPAN, "new_dict"), Lit(DUMMY_SPAN, Int(0))),
         )
-        report = egraph.extract_report()
-        assert isinstance(report, Best)
+        assert len(res) == 1
+        report = res[0]
+        assert isinstance(report, ExtractBest)
         expr = report.termdag.term_to_expr(report.term, DUMMY_SPAN)
         assert sort.load(expr) == {"a": 2, "b": 2}
 
@@ -95,7 +96,7 @@ class TestEval:
         locals_ = sort.store(locals())
         x_expr = sort.store("x")
         y_expr = sort.store("y")
-        egraph.run_program(
+        res = egraph.run_program(
             ActionCommand(
                 Let(
                     DUMMY_SPAN,
@@ -113,8 +114,9 @@ class TestEval:
             ),
             Extract(DUMMY_SPAN, Var(DUMMY_SPAN, "res"), Lit(DUMMY_SPAN, Int(0))),
         )
-        report = egraph.extract_report()
-        assert isinstance(report, Best)
+        assert len(res) == 1
+        report = res[0]
+        assert isinstance(report, ExtractBest)
         expr = report.termdag.term_to_expr(report.term, DUMMY_SPAN)
         assert sort.load(expr) == 3
 

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -359,14 +359,14 @@ convert_enums!(
         RunScheduleOutput(report: RunReport)
             b -> egglog::CommandOutput::RunSchedule(b.report.clone().into()),
             egglog::CommandOutput::RunSchedule(report) => RunScheduleOutput {report: report.into()};
-        PrintFunctionOuput(function: Function, termdag: TermDag, terms: Vec<(Term, Term)>, mode: PrintFunctionMode)
+        PrintFunctionOutput(function: Function, termdag: TermDag, terms: Vec<(Term, Term)>, mode: PrintFunctionMode)
             v -> egglog::CommandOutput::PrintFunction(
                 v.function.0.clone(),
                 (&v.termdag).into(),
                 v.terms.iter().map(|(l, r)| (l.into(), r.into())).collect(),
                 v.mode.clone().into()
             ),
-            egglog::CommandOutput::PrintFunction(function, termdag, terms, mode) => PrintFunctionOuput {
+            egglog::CommandOutput::PrintFunction(function, termdag, terms, mode) => PrintFunctionOutput {
                 function: Function(function.clone()),
                 termdag: termdag.into(),
                 terms: terms.iter().map(|(l, r)| (l.into(), r.into())).collect(),

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -117,16 +117,15 @@ convert_enums!(
                 args: a.to_vec()
             }
     };
+    egglog::ast::PrintFunctionMode: "{}" => PrintFunctionMode {
+        DefaultPrintFunctionMode()
+            _d -> egglog::ast::PrintFunctionMode::Default,
+            egglog::ast::PrintFunctionMode::Default => DefaultPrintFunctionMode {};
+        CSVPrintFunctionMode()
+            _d -> egglog::ast::PrintFunctionMode::CSV,
+            egglog::ast::PrintFunctionMode::CSV => CSVPrintFunctionMode {}
+    };
     egglog::ast::Command: "{}" => Command {
-        SetOption(name: String, value: Expr)
-            s -> egglog::ast::Command::SetOption{
-                name: (&s.name).into(),
-                value: (&s.value).into()
-            },
-            egglog::ast::Command::SetOption {name, value} => SetOption {
-                name: name.to_string(),
-                value: value.into()
-            };
         Datatype(span: Span, name: String, variants: Vec<Variant>)
             d -> egglog::ast::Command::Datatype {
                 span: d.span.clone().into(),
@@ -149,14 +148,14 @@ convert_enums!(
                 presort_and_args: presort_and_args.as_ref().map(|(p, a)| (p.to_string(), a.iter().map(|e| e.into()).collect())),
                 span: span.into()
             };
-        Function(span: Span, name: String, schema: Schema, merge: Option<Expr>)
+        FunctionCommand(span: Span, name: String, schema: Schema, merge: Option<Expr>)
             f -> egglog::ast::Command::Function{
                 span: f.span.clone().into(),
                 name: (&f.name).into(),
                 schema: (&f.schema).into(),
                 merge: f.merge.as_ref().map(|e| e.into())
             },
-            egglog::ast::Command::Function {span, name, schema, merge} => Function {
+            egglog::ast::Command::Function {span, name, schema, merge} => FunctionCommand {
                 span: span.into(),
                 name: name.to_string(),
                 schema: schema.into(),
@@ -215,12 +214,14 @@ convert_enums!(
         Check(span: Span, facts: Vec<Fact_>)
             c -> egglog::ast::Command::Check(c.span.clone().into(), c.facts.iter().map(|f| f.into()).collect()),
             egglog::ast::Command::Check(span, facts) => Check { span: span.into(), facts: facts.iter().map(|f| f.into()).collect() };
-        PrintFunction(span: Span, name: String, length: usize)
-            p -> egglog::ast::Command::PrintFunction(p.span.clone().into(), (&p.name).into(), p.length),
-            egglog::ast::Command::PrintFunction(span, n, l) => PrintFunction {
+        PrintFunction(span: Span, name: String, length: Option<usize>, filename: Option<String>, mode: PrintFunctionMode)
+            p -> egglog::ast::Command::PrintFunction(p.span.clone().into(), (&p.name).into(), p.length, p.filename.clone(), p.mode.clone().into()),
+            egglog::ast::Command::PrintFunction(span, n, l, f, m) => PrintFunction {
                 span: span.into(),
                 name: n.to_string(),
-                length: *l
+                length: *l,
+                filename: f.clone(),
+                mode: m.into()
             };
         PrintSize(span: Span, name: Option<String>)
             p -> egglog::ast::Command::PrintSize(p.span.clone().into(), p.name.as_ref().map(|n| n.into())),
@@ -325,27 +326,55 @@ convert_enums!(
             n -> egglog::ast::Subdatatypes::NewSort((&n.name).into(), n.args.iter().map(|e| e.into()).collect()),
             egglog::ast::Subdatatypes::NewSort(name, args) => NewSort { name: name.to_string(), args: args.iter().map(|e| e.into()).collect() }
     };
-    egglog::ExtractReport: "{:?}" => ExtractReport {
-        Best(termdag: TermDag, cost: DefaultCost, term: Term)
-            b -> egglog::ExtractReport::Best {
-                termdag: (&b.termdag).into(),
-                cost: b.cost,
-                term: (&b.term).into()
-            },
-            egglog::ExtractReport::Best {termdag, cost, term} => Best {
+    egglog::CommandOutput: "{}" => CommandOutput {
+        PrintFunctionSize(size: usize)
+            b -> egglog::CommandOutput::PrintFunctionSize(b.size),
+            egglog::CommandOutput::PrintFunctionSize(size) => PrintFunctionSize {size: *size};
+        PrintAllFunctionsSize(sizes: Vec<(String, usize)>)
+            b -> egglog::CommandOutput::PrintAllFunctionsSize(b.sizes.clone()),
+            egglog::CommandOutput::PrintAllFunctionsSize(sizes) => PrintAllFunctionsSize {sizes: sizes.clone()};
+        ExtractBest(termdag: TermDag, cost: DefaultCost, term: Term)
+            b -> egglog::CommandOutput::ExtractBest(
+                (&b.termdag).into(),
+                b.cost,
+                (&b.term).into()
+            ),
+            egglog::CommandOutput::ExtractBest(termdag, cost, term) => ExtractBest {
                 termdag: termdag.into(),
                 cost: *cost,
                 term: term.into()
             };
-        Variants(termdag: TermDag, terms: Vec<Term>)
-            v -> egglog::ExtractReport::Variants {
-                termdag: (&v.termdag).into(),
-                terms: v.terms.iter().map(|v| v.into()).collect()
-            },
-            egglog::ExtractReport::Variants {termdag, terms} => Variants {
+        ExtractVariants(termdag: TermDag, terms: Vec<Term>)
+            v -> egglog::CommandOutput::ExtractVariants(
+                (&v.termdag).into(),
+                v.terms.iter().map(|v| v.into()).collect()
+            ),
+            egglog::CommandOutput::ExtractVariants(termdag, terms) => ExtractVariants {
                 termdag: termdag.into(),
                 terms: terms.iter().map(|v| v.into()).collect()
-            }
+            };
+        OverallStatistics(report: RunReport)
+            b -> egglog::CommandOutput::OverallStatistics(b.report.clone().into()),
+            egglog::CommandOutput::OverallStatistics(report) => OverallStatistics {report: report.into()};
+        RunScheduleOutput(report: RunReport)
+            b -> egglog::CommandOutput::RunSchedule(b.report.clone().into()),
+            egglog::CommandOutput::RunSchedule(report) => RunScheduleOutput {report: report.into()};
+        PrintFunctionOuput(function: Function, termdag: TermDag, terms: Vec<(Term, Term)>, mode: PrintFunctionMode)
+            v -> egglog::CommandOutput::PrintFunction(
+                v.function.0.clone(),
+                (&v.termdag).into(),
+                v.terms.iter().map(|(l, r)| (l.into(), r.into())).collect(),
+                v.mode.clone().into()
+            ),
+            egglog::CommandOutput::PrintFunction(function, termdag, terms, mode) => PrintFunctionOuput {
+                function: Function(function.clone()),
+                termdag: termdag.into(),
+                terms: terms.iter().map(|(l, r)| (l.into(), r.into())).collect(),
+                mode: mode.into()
+            };
+        UserDefinedOutput(output: UserDefinedCommandOutput)
+            b -> egglog::CommandOutput::UserDefined(b.output.0.clone()),
+            egglog::CommandOutput::UserDefined(output) => UserDefinedOutput {output: UserDefinedCommandOutput(output.clone())}
     };
     egglog::ast::Span: "{:?}" => Span {
         PanicSpan()
@@ -547,3 +576,48 @@ impl<'py> IntoPyObject<'py> for WrappedDuration {
         .clone())
     }
 }
+
+#[pyclass()]
+#[derive(Clone)]
+pub struct UserDefinedCommandOutput(Arc<dyn egglog::UserDefinedCommandOutput>);
+
+#[pymethods]
+impl UserDefinedCommandOutput {
+    fn __str__(&self) -> String {
+        format!("{}", self.0)
+    }
+    fn __repr__(&self) -> String {
+        format!("{:}", self.0)
+    }
+}
+
+impl PartialEq for UserDefinedCommandOutput {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl std::cmp::Eq for UserDefinedCommandOutput {}
+
+#[pyclass()]
+#[derive(Clone)]
+pub struct Function(egglog::Function);
+
+#[pymethods]
+impl Function {
+    fn __str__(&self) -> String {
+        format!("Function(name={})", self.0.name())
+    }
+
+    fn name(&self) -> String {
+        self.0.name().to_string()
+    }
+}
+
+impl PartialEq for Function {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.name() == other.0.name()
+    }
+}
+
+impl std::cmp::Eq for Function {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,8 @@ fn bindings(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<crate::egraph::EGraph>()?;
     m.add_class::<crate::error::EggSmolError>()?;
     m.add_class::<crate::termdag::TermDag>()?;
-
+    m.add_class::<crate::conversions::UserDefinedCommandOutput>()?;
+    m.add_class::<crate::conversions::Function>()?;
     crate::conversions::add_structs_to_module(m)?;
     crate::conversions::add_enums_to_module(m)?;
 

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -7,6 +7,10 @@ use crate::egraph::EGraph;
 #[pyclass()]
 pub struct SerializedEGraph {
     pub egraph: egraph_serialize::EGraph,
+    #[pyo3(get)]
+    pub truncated_functions: Vec<String>,
+    #[pyo3(get)]
+    pub discarded_functions: Vec<String>,
 }
 
 #[pymethods]


### PR DESCRIPTION
Bump egglog version which changes running commands to return structured output and adds fields on the serialized e-graph to show if functions were omitted.

Follow up PRs will expose this functionality at the high level.