### PR TITLE
Add support for `set_cost` action to have row level costs for extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ Source.*
 inlined
 visualizer.tgz
 package
+.mypy_cache/

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@ _This project uses semantic versioning_
 
 ## UNRELEASED
 
+- Add support for `set_cost` action to have row level costs for extraction [#343](https://github.com/egraphs-good/egglog-python/pull/343)
 - Add `egraph.function_values(fn)` to export all function values like `print-function` [#340](https://github.com/egraphs-good/egglog-python/pull/340)
 - Add `egraph.stats()` method to print overall stats [#339](https://github.com/egraphs-good/egglog-python/pull/339)
 - Add `all_function_sizes` and `function_size` EGraph methods [#338](https://github.com/egraphs-good/egglog-python/pull/338)

--- a/docs/reference/egglog-translation.md
+++ b/docs/reference/egglog-translation.md
@@ -283,7 +283,7 @@ so dynamic costs can be created in rules.
 It does this by creating a new table for each function you set the cost for that maps the arguments to an i64.
 
 _Note: Unlike in egglog, where you have to declare which functions support custom costs, in Python all functions
-are automatically regeistered to create a custom cost table when they are constructed_
+are automatically registered to create a custom cost table when they are constructed_
 
 ## Defining Rules
 

--- a/docs/reference/egglog-translation.md
+++ b/docs/reference/egglog-translation.md
@@ -268,6 +268,23 @@ except BaseException as e:
     print(e)
 ```
 
+### Set Cost
+
+You can also set the cost of individual values, like the egglog experimental feature, to override the default cost from constructing a function:
+
+```{code-cell} python
+# egg: (set-cost (fib 0) 1)
+egraph.register(set_cost(fib(0), 1))
+```
+
+This will be taken into account when extracting. Any value that can be converted to an `i64` is supported as a cost,
+so dynamic costs can be created in rules.
+
+It does this by creating a new table for each function you set the cost for that maps the arguments to an i64.
+
+_Note: Unlike in egglog, where you have to declare which functions support custom costs, in Python all functions
+are automatically regeistered to create a custom cost table when they are constructed_
+
 ## Defining Rules
 
 To define rules in Python, we create a rule with the `rule(*facts).then(*actions) (rule ...)` command in egglog.

--- a/python/egglog/declarations.py
+++ b/python/egglog/declarations.py
@@ -69,6 +69,7 @@ __all__ = [
     "SaturateDecl",
     "ScheduleDecl",
     "SequenceDecl",
+    "SetCostDecl",
     "SetDecl",
     "SpecialFunctions",
     "TypeOrVarRef",
@@ -854,7 +855,14 @@ class PanicDecl:
     msg: str
 
 
-ActionDecl: TypeAlias = LetDecl | SetDecl | ExprActionDecl | ChangeDecl | UnionDecl | PanicDecl
+@dataclass(frozen=True)
+class SetCostDecl:
+    tp: JustTypeRef
+    expr: CallDecl
+    cost: ExprDecl
+
+
+ActionDecl: TypeAlias = LetDecl | SetDecl | ExprActionDecl | ChangeDecl | UnionDecl | PanicDecl | SetCostDecl
 
 
 ##

--- a/python/egglog/examples/jointree.py
+++ b/python/egglog/examples/jointree.py
@@ -19,7 +19,7 @@ class JoinTree(Expr):
 
     def join(self, other: JoinTree) -> JoinTree: ...
 
-    @method(merge=lambda old, new: old.min(new))
+    @method(merge=lambda old, new: old.min(new))  # type:ignore[prop-decorator]
     @property
     def size(self) -> i64: ...
 

--- a/python/egglog/examples/jointree.py
+++ b/python/egglog/examples/jointree.py
@@ -1,0 +1,67 @@
+# mypy: disable-error-code="empty-body"
+
+"""
+Join Tree (custom costs)
+========================
+
+Example of using custom cost functions for jointree.
+
+From https://egraphs.zulipchat.com/#narrow/stream/328972-general/topic/How.20can.20I.20find.20the.20tree.20associated.20with.20an.20extraction.3F
+"""
+
+from __future__ import annotations
+
+from egglog import *
+
+
+class JoinTree(Expr):
+    def __init__(self, name: StringLike) -> None: ...
+
+    def join(self, other: JoinTree) -> JoinTree: ...
+
+    @method(merge=lambda old, new: old.min(new))
+    @property
+    def size(self) -> i64: ...
+
+
+ra = JoinTree("a")
+rb = JoinTree("b")
+rc = JoinTree("c")
+rd = JoinTree("d")
+re = JoinTree("e")
+rf = JoinTree("f")
+
+query = ra.join(rb).join(rc).join(rd).join(re).join(rf)
+
+egraph = EGraph()
+egraph.register(
+    set_(ra.size).to(50),
+    set_(rb.size).to(200),
+    set_(rc.size).to(10),
+    set_(rd.size).to(123),
+    set_(re.size).to(10000),
+    set_(rf.size).to(1),
+)
+
+
+@egraph.register
+def _rules(s: String, a: JoinTree, b: JoinTree, c: JoinTree, asize: i64, bsize: i64):
+    # cost of relation is its size minus 1, since the string arg will have a cost of 1 as well
+    yield rule(JoinTree(s).size == asize).then(set_cost(JoinTree(s), asize - 1))
+    # cost/size of join is product of sizes
+    yield rule(a.join(b), a.size == asize, b.size == bsize).then(
+        set_(a.join(b).size).to(asize * bsize), set_cost(a.join(b), asize * bsize)
+    )
+    # associativity
+    yield rewrite(a.join(b)).to(b.join(a))
+    # commutativity
+    yield rewrite(a.join(b).join(c)).to(a.join(b.join(c)))
+
+
+egraph.register(query)
+egraph.run(1000)
+print(egraph.extract(query))
+print(egraph.extract(query.size))
+
+
+egraph

--- a/python/egglog/pretty.py
+++ b/python/egglog/pretty.py
@@ -121,8 +121,8 @@ def pretty_callable_ref(
         if include_all_args:
             signature = decls.get_callable_decl(ref).signature
             assert isinstance(signature, FunctionSignature)
-            args: list[ExprDecl] = [UnboundVarDecl(ARG_STR)] * len(signature.arg_types)
-            return f"{res[0]}({', '.join(context(a, parens=False, unwrap_lit=True) for a in args)})"
+            correct_args: list[ExprDecl] = [UnboundVarDecl(ARG_STR)] * len(signature.arg_types)
+            return f"{res[0]}({', '.join(context(a, parens=False, unwrap_lit=True) for a in correct_args)})"
         return res[0]
     return res
 

--- a/python/egglog/pretty.py
+++ b/python/egglog/pretty.py
@@ -98,6 +98,7 @@ def pretty_callable_ref(
     ref: CallableRef,
     first_arg: ExprDecl | None = None,
     bound_tp_params: tuple[JustTypeRef, ...] | None = None,
+    include_all_args: bool = False,
 ) -> str:
     """
     Pretty print a callable reference, using a dummy value for
@@ -115,6 +116,13 @@ def pretty_callable_ref(
     # Either returns a function or a function with args. If args are provided, they would just be called,
     # on the function, so return them, because they are dummies
     if isinstance(res, tuple):
+        # If we want to include all args as ARG_STR, then we need to figure out how many to use
+        # used for set_cost so that `cost(E(...))` will show up as a call
+        if include_all_args:
+            signature = decls.get_callable_decl(ref).signature
+            assert isinstance(signature, FunctionSignature)
+            args: list[ExprDecl] = [UnboundVarDecl(ARG_STR)] * len(signature.arg_types)
+            return f"{res[0]}({', '.join(context(a, parens=False, unwrap_lit=True) for a in args)})"
         return res[0]
     return res
 
@@ -190,6 +198,9 @@ class TraverseContext:
                 pass
             case DefaultRewriteDecl():
                 pass
+            case SetCostDecl(_, e, c):
+                self(e)
+                self(c)
             case _:
                 assert_never(decl)
 
@@ -285,6 +296,8 @@ class PrettyContext:
                 return f"{change}({self(expr)})", "action"
             case PanicDecl(s):
                 return f"panic({s!r})", "action"
+            case SetCostDecl(_, expr, cost):
+                return f"set_cost({self(expr)}, {self(cost, unwrap_lit=True)})", "action"
             case EqDecl(_, left, right):
                 return f"eq({self(left)}).to({self(right)})", "fact"
             case RulesetDecl(rules):


### PR DESCRIPTION
This re-implements the syntactic macro in the egglog experimental to create a new table for each function to store its cost. It re-uses the custom extractor which looks up in this table.

I talked to @yihongz and we discussed different ways to implement this, from changing syntactic macros to take Expr instead of Sexpr, but settled on just having me re-implement the syntax.

Closes https://github.com/egraphs-good/egglog-python/issues/332