### PR TITLE
Add PyObject.to_int

### DIFF
--- a/python/egglog/builtins.py
+++ b/python/egglog/builtins.py
@@ -1022,6 +1022,9 @@ class PyObject(BuiltinExpr, egg_sort="PyObject"):
     @method(egg_fn="py-to-bool")
     def to_bool(self) -> Bool: ...
 
+    @method(egg_fn="py-to-int")
+    def to_int(self) -> i64: ...
+
     @method(egg_fn="py-dict-update")
     def dict_update(self, *keys_and_values: object) -> PyObject: ...
 

--- a/src/py_object_sort.rs
+++ b/src/py_object_sort.rs
@@ -170,6 +170,15 @@ impl BaseSort for PyObjectSort {
                 }
             }
         );
+        // (py-to-int <obj>)
+        add_primitive!(
+            eg,
+            "py-to-int" = |x: PyPickledValue| -?> i64 {
+                {
+                    attach("py-to-int", move |py| load(py, &x)?.extract())
+                }
+            }
+        );
         // (py-from-string <str>)
         add_primitive!(
             eg,


### PR DESCRIPTION
This PR implements `py-to-int` and `PyObject.to_int` so that a Python `int` stored as `PyObject` can be converted into a `i64`.

Reason:

I am exploring (or maybe i'm abusing) the `PyObject` API to store Python objects into the EGraph and allowing them to generate equivalances in Python code back into EGraph. See example gist: https://gist.github.com/sklam/f141efe69bf86182ed185274b6648e93

